### PR TITLE
Update golang version 1.15.0 to 1.16.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.0-alpine AS build
+FROM golang:1.16.7-alpine AS build
 
 RUN apk add --update git libc-dev
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.14.3-stretch
+FROM golang:1.16.7-stretch
 
 RUN apt-get update && apt-get install -y unzip && \
   curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \


### PR DESCRIPTION
https://github.com/zaiminc/gocat/pull/288/checks?check_run_id=3256235046

>  > [linux/amd64 build 7/7] RUN go build -o ./gocat:
> #30 1.114 /go/pkg/mod/k8s.io/client-go@v0.22.0/plugin/pkg/client/auth/exec/metrics.go:21:2: package io/fs is not in GOROOT (/usr/local/go/src/io/fs)
> ------
> Dockerfile:12
> --------------------
>  10 |     COPY . .
>  11 |     
>   12 | >>> RUN go build -o ./gocat
>   13 |     
>   14 |     FROM alpine
> --------------------
> error: failed to solve: process "/bin/sh -c go build -o ./gocat" did not complete successfully: exit code: 1
> Error: Process completed with exit code 1.

Comments that the problem was solved after upgrading to 1.16 https://github.com/spf13/viper/issues/1161#issuecomment-881912199