### PR TITLE
add registryId as ecr input

### DIFF
--- a/autodeploy.go
+++ b/autodeploy.go
@@ -54,7 +54,7 @@ func (a AutoDeploy) checkAndDeploy(dp DeployProject, phase DeployPhase) {
 		log.Print(err)
 		return
 	}
-	tag, err := ecr.FindImageTagByRegexp(dp.ECRRepository(), dp.FilterRegexp(), dp.TargetRegexp(), ImageTagVars{Branch: dp.DefaultBranch()})
+	tag, err := ecr.FindImageTagByRegexp(dp.ECRRegistryId(), dp.ECRRepository(), dp.FilterRegexp(), dp.TargetRegexp(), ImageTagVars{Branch: dp.DefaultBranch()})
 	if currentTag == tag || err != nil {
 		log.Printf("[INFO] Auto Deploy (%s:%s) is skipped", dp.ID, phase.Name)
 		return

--- a/aws.go
+++ b/aws.go
@@ -54,7 +54,7 @@ func (e ECRClient) FindImageTagByRegexp(repo string, rawFilterRegexp string, raw
 	if err != nil {
 		return "", fmt.Errorf("[ERROR] targetRegexp cannot be parsed: %s", rawTargetRegexp)
 	}
-	arr := e.describeImages(&repo, nil)
+	arr := e.describeImages(&registryId, &repo, nil)
 	for _, v := range arr {
 		for _, vv1 := range v.ImageTags {
 			if regexp.MustCompile(filterRegexp).FindStringSubmatch(*vv1) == nil {
@@ -82,7 +82,7 @@ func (e ECRClient) describeImages(registryId *string, repo *string, nextToken *s
 		return []*ecr.ImageDetail{}
 	}
 	if outputs.NextToken != nil {
-		return append(outputs.ImageDetails, e.describeImages(repo, outputs.NextToken)...)
+		return append(outputs.ImageDetails, e.describeImages(registryId, repo, outputs.NextToken)...)
 	}
 	return outputs.ImageDetails
 }

--- a/aws.go
+++ b/aws.go
@@ -44,7 +44,7 @@ func CreateECRInstance() (ECRClient, error) {
 	return ECRClient{client: ecr.New(sess, aws.NewConfig().WithRegion("ap-northeast-1"))}, nil
 }
 
-func (e ECRClient) FindImageTagByRegexp(repo string, rawFilterRegexp string, rawTargetRegexp string, vars ImageTagVars) (string, error) {
+func (e ECRClient) FindImageTagByRegexp(registryId string, repo string, rawFilterRegexp string, rawTargetRegexp string, vars ImageTagVars) (string, error) {
 	vars.Branch = strings.Replace(vars.Branch, "/", "_", -1)
 	filterRegexp, err := vars.Parse(rawFilterRegexp)
 	if err != nil {

--- a/aws.go
+++ b/aws.go
@@ -70,8 +70,9 @@ func (e ECRClient) FindImageTagByRegexp(repo string, rawFilterRegexp string, raw
 	return "", fmt.Errorf("[ERROR] NotFound specified image tag")
 }
 
-func (e ECRClient) describeImages(repo *string, nextToken *string) []*ecr.ImageDetail {
+func (e ECRClient) describeImages(registryId *string, repo *string, nextToken *string) []*ecr.ImageDetail {
 	input := &ecr.DescribeImagesInput{
+		RegistryId: registryId,
 		RepositoryName: repo,
 		NextToken:      nextToken,
 	}

--- a/model_combine.go
+++ b/model_combine.go
@@ -45,7 +45,7 @@ func (self ModelCombine) Deploy(pj DeployProject, phase string, option DeployOpt
 	if err != nil {
 		return o, err
 	}
-	option.Tag, err = ecr.FindImageTagByRegexp(pj.ECRRepository(), pj.FilterRegexp(), pj.TargetRegexp(), ImageTagVars{Branch: option.Branch, Phase: phase})
+	option.Tag, err = ecr.FindImageTagByRegexp(pj.ECRRegistryId(), pj.ECRRepository(), pj.FilterRegexp(), pj.TargetRegexp(), ImageTagVars{Branch: option.Branch, Phase: phase})
 	if err != nil {
 		return o, err
 	}

--- a/model_job.go
+++ b/model_job.go
@@ -49,7 +49,7 @@ func (self ModelJob) Deploy(pj DeployProject, phase string, option DeployOption)
 		if err != nil {
 			return o, err
 		}
-		tag, err = ecr.FindImageTagByRegexp(pj.ECRRepository(), pj.FilterRegexp(), pj.TargetRegexp(), ImageTagVars{Branch: option.Branch, Phase: phase})
+		tag, err = ecr.FindImageTagByRegexp(pj.ECRRegistryId(), pj.ECRRepository(), pj.FilterRegexp(), pj.TargetRegexp(), ImageTagVars{Branch: option.Branch, Phase: phase})
 		if err != nil {
 			return o, err
 		}

--- a/model_kustomize.go
+++ b/model_kustomize.go
@@ -36,7 +36,7 @@ func (self ModelKustomize) Prepare(pj DeployProject, phase string, branch string
 		if err != nil {
 			return o, err
 		}
-		tag, err = ecr.FindImageTagByRegexp(pj.ECRRepository(), pj.FilterRegexp(), pj.TargetRegexp(), ImageTagVars{Branch: branch, Phase: phase})
+		tag, err = ecr.FindImageTagByRegexp(pj.ECRRegistryId(), pj.ECRRepository(), pj.FilterRegexp(), pj.TargetRegexp(), ImageTagVars{Branch: branch, Phase: phase})
 		if err != nil {
 			return o, err
 		}

--- a/model_lambda.go
+++ b/model_lambda.go
@@ -36,7 +36,7 @@ func (self ModelLambda) Deploy(pj DeployProject, phase string, option DeployOpti
 		if err != nil {
 			return o, err
 		}
-		tag, err = ecr.FindImageTagByRegexp(pj.ECRRepository(), pj.FilterRegexp(), pj.TargetRegexp(), ImageTagVars{Branch: option.Branch, Phase: phase})
+		tag, err = ecr.FindImageTagByRegexp(pj.ECRRegistryId(), pj.ECRRepository(), pj.FilterRegexp(), pj.TargetRegexp(), ImageTagVars{Branch: option.Branch, Phase: phase})
 		if err != nil {
 			return o, err
 		}

--- a/project.go
+++ b/project.go
@@ -107,6 +107,14 @@ func (pj DeployProject) ECRRepository() string {
 	return strings.Join(path[1:], "/")
 }
 
+func (pj DeployProject) ECRRegistryId() string {
+	path := strings.Split(pj.dockerRegistry, ".")
+	if len(path) < 2 {
+		return ""
+	}
+	return path[0:]
+}
+
 type ProjectList struct {
 	Items []DeployProject
 }

--- a/project.go
+++ b/project.go
@@ -112,7 +112,7 @@ func (pj DeployProject) ECRRegistryId() string {
 	if len(path) < 2 {
 		return ""
 	}
-	return path[0:]
+	return path[0]
 }
 
 type ProjectList struct {


### PR DESCRIPTION
I use multiple AWS accounts, so I wanna sometimes specify another AWS account's ECR that not gocat working on.

This PR enable to specify ECR Registry ID.
https://docs.aws.amazon.com/sdk-for-go/api/service/ecr/#DescribeImagesInput