### PR TITLE
fix cant up local server

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,8 @@
 FROM golang:1.19.4-bullseye
 
-RUN apt-get update && apt-get install -y unzip && \
+RUN apt-get update && \
+  apt-get install -y build-essential && \
+  apt-get install -y unzip && \
   curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
   unzip awscliv2.zip && \
   ./aws/install


### PR DESCRIPTION
I ran "docker-compose up" in my local environment.
However, the following error occurred and it could not be started.
```
bot_1  | 4:23:47 build       | Building...
bot_1  | 4:24:14 main        | Build Failed:
bot_1  |  go: downloading github.com/aws/aws-sdk-go v1.44.168
bot_1  | go: downloading github.com/go-git/go-git/v5 v5.5.1
bot_1  | go: downloading github.com/go-git/go-billy/v5 v5.3.1
bot_1  | go: downloading github.com/nlopes/slack v0.6.1-0.20191106133607-d06c2a2b3249
bot_1  | go: downloading github.com/shurcooL/githubv4 v0.0.0-20191006152017-6d1ea27df521
bot_1  | go: downloading golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b
bot_1  | go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
bot_1  | go: downloading gopkg.in/yaml.v2 v2.4.0
bot_1  | go: downloading k8s.io/api v0.26.0
bot_1  | go: downloading k8s.io/apimachinery v0.26.0
bot_1  | go: downloading k8s.io/client-go v0.26.0
bot_1  | go: downloading sigs.k8s.io/kustomize/api v0.12.1
bot_1  | go: downloading github.com/gorilla/websocket v1.2.0
bot_1  | go: downloading github.com/pkg/errors v0.9.1
bot_1  | go: downloading github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4
bot_1  | go: downloading github.com/emirpasic/gods v1.18.1
bot_1  | go: downloading github.com/sergi/go-diff v1.1.0
bot_1  | go: downloading github.com/imdario/mergo v0.3.13
bot_1  | go: downloading github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f
bot_1  | go: downloading sigs.k8s.io/kustomize/kyaml v0.13.9
bot_1  | go: downloading sigs.k8s.io/yaml v1.3.0
bot_1  | go: downloading github.com/gogo/protobuf v1.3.2
bot_1  | go: downloading github.com/google/gofuzz v1.1.0
bot_1  | go: downloading golang.org/x/net v0.3.1-0.20221206200815-1e63c2f08a10
bot_1  | go: downloading github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99
bot_1  | go: downloading golang.org/x/sys v0.3.0
bot_1  | go: downloading github.com/go-git/gcfg v1.5.0
bot_1  | go: downloading github.com/pjbgf/sha1cd v0.2.3
bot_1  | go: downloading gopkg.in/inf.v0 v0.9.1
bot_1  | go: downloading k8s.io/klog/v2 v2.80.1
bot_1  | go: downloading k8s.io/utils v0.0.0-20221107191617-1a15be271d1d
bot_1  | go: downloading sigs.k8s.io/structured-merge-diff/v4 v4.2.3
bot_1  | go: downloading sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2
bot_1  | go: downloading github.com/spf13/pflag v1.0.5
bot_1  | go: downloading golang.org/x/term v0.3.0
bot_1  | go: downloading github.com/kevinburke/ssh_config v1.2.0
bot_1  | go: downloading github.com/skeema/knownhosts v1.1.0
bot_1  | go: downloading github.com/xanzy/ssh-agent v0.3.3
bot_1  | go: downloading golang.org/x/crypto v0.3.0
bot_1  | go: downloading github.com/cloudflare/circl v1.1.0
bot_1  | go: downloading gopkg.in/warnings.v0 v0.1.2
bot_1  | go: downloading github.com/golang/protobuf v1.5.2
bot_1  | go: downloading github.com/google/gnostic v0.5.7-v3refs
bot_1  | go: downloading golang.org/x/time v0.0.0-20220210224613-90d013bbcef8
bot_1  | go: downloading github.com/davecgh/go-spew v1.1.1
bot_1  | go: downloading github.com/go-logr/logr v1.2.3
bot_1  | go: downloading github.com/json-iterator/go v1.1.12
bot_1  | go: downloading google.golang.org/protobuf v1.28.1
bot_1  | go: downloading k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280
bot_1  | go: downloading golang.org/x/text v0.5.0
bot_1  | go: downloading gopkg.in/yaml.v3 v3.0.1
bot_1  | go: downloading github.com/go-errors/errors v1.0.1
bot_1  | go: downloading github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
bot_1  | go: downloading github.com/modern-go/reflect2 v1.0.2
bot_1  | go: downloading github.com/go-openapi/jsonreference v0.20.0
bot_1  | go: downloading github.com/go-openapi/swag v0.19.14
bot_1  | go: downloading github.com/google/go-cmp v0.5.9
bot_1  | go: downloading github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
bot_1  | go: downloading github.com/emicklei/go-restful/v3 v3.9.0
bot_1  | go: downloading github.com/go-openapi/jsonpointer v0.19.5
bot_1  | go: downloading github.com/mailru/easyjson v0.7.6
bot_1  | go: downloading github.com/josharian/intern v1.0.0
bot_1  | go: downloading github.com/jmespath/go-jmespath v0.4.0
bot_1  | # github.com/pjbgf/sha1cd/cgo
bot_1  | cgo: C compiler "gcc" not found: exec: "gcc": executable file not found in $PATH
```

I have resolved this issue.