### PR TITLE
Fix docker build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.19.4-bullseye AS build
 
-RUN apt update && apt install git libc-dev
+RUN apt update && apt install -y git libc-dev
 
 WORKDIR /src
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,8 @@
 FROM golang:1.19.4-bullseye
 
-RUN apt-get update && apt-get install -y unzip && \
+RUN apt-get update && \
+  apt-get install -y build-essential && \
+  apt-get install -y unzip && \
   curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
   unzip awscliv2.zip && \
   ./aws/install


### PR DESCRIPTION
I ran "docker build" in my local environment.
But I got the following error.
```
 => [build 1/7] FROM docker.io/library/golang:1.19.4-bullseye                                                                                                                                                                        0.5s
 => ERROR [build 2/7] RUN apt update && apt install git libc-dev                                                                                                                                                                     6.4s
------
 > [build 2/7] RUN apt update && apt install git libc-dev:
#8 0.414
#8 0.414 WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
#8 0.414
#8 0.841 Get:1 http://deb.debian.org/debian bullseye InRelease [116 kB]
#8 0.988 Get:2 http://deb.debian.org/debian-security bullseye-security InRelease [48.4 kB]
#8 1.053 Get:3 http://deb.debian.org/debian bullseye-updates InRelease [44.1 kB]
#8 1.119 Get:4 http://deb.debian.org/debian bullseye/main amd64 Packages [8183 kB]
#8 4.150 Get:5 http://deb.debian.org/debian-security bullseye-security/main amd64 Packages [218 kB]
#8 4.199 Get:6 http://deb.debian.org/debian bullseye-updates/main amd64 Packages [14.6 kB]
#8 4.855 Fetched 8624 kB in 4s (1950 kB/s)
#8 4.855 Reading package lists...
#8 5.415 Building dependency tree...
#8 5.536 Reading state information...
#8 5.548 7 packages can be upgraded. Run 'apt list --upgradable' to see them.
#8 5.553
#8 5.553 WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
#8 5.553
#8 5.561 Reading package lists...
#8 6.071 Building dependency tree...
#8 6.184 Reading state information...
#8 6.296 libc6-dev is already the newest version (2.31-13+deb11u5).
#8 6.296 Suggested packages:
#8 6.296   gettext-base git-daemon-run | git-daemon-sysvinit git-doc git-el git-email
#8 6.296   git-gui gitk gitweb git-cvs git-mediawiki git-svn
#8 6.296 Recommended packages:
#8 6.296   patch less
#8 6.310 The following packages will be upgraded:
#8 6.310   git
#8 6.314 1 upgraded, 0 newly installed, 0 to remove and 6 not upgraded.
#8 6.314 Need to get 5514 kB of archives.
#8 6.314 After this operation, 22.5 kB of additional disk space will be used.
#8 6.314 Do you want to continue? [Y/n] Abort.
------
executor failed running [/bin/sh -c apt update && apt install git libc-dev]: exit code: 1
```

I have resolved this issue.

please check the diff.
[1a8417faf9c38022d55f6f308f8ef988b2bded32](https://github.com/zaiminc/gocat/pull/715/commits/1a8417faf9c38022d55f6f308f8ef988b2bded32)