### PR TITLE
Fix unknown authority error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.19.4-bullseye AS build
 
-RUN apt update && apt install git libc-dev
+RUN apt update && apt install -y git libc-dev
 
 WORKDIR /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ FROM debian:bullseye
 
 WORKDIR /src
 COPY --from=build /src/gocat /src/gocat
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 CMD /src/gocat
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,8 @@
 FROM golang:1.19.4-bullseye
 
-RUN apt-get update && apt-get install -y unzip && \
+RUN apt-get update && \
+  apt-get install -y build-essential && \
+  apt-get install -y unzip && \
   curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
   unzip awscliv2.zip && \
   ./aws/install


### PR DESCRIPTION
I ran gocat in my eks environment as a pod.
But I got the following error.
```
[ERROR]  Get "https://github.com/my-org/my-repo.git/info/refs?service=git-upload-pack": x509: certificate signed by unknown authority
```

I resolved this issue by copying the ca certificate from the build image.

please check the diff.
[a03f85352a72cfac9f1d6909945d41d5f46c4f1c](https://github.com/zaiminc/gocat/pull/716/commits/a03f85352a72cfac9f1d6909945d41d5f46c4f1c)