### PR TITLE
Rename DeployProject FilterRegexp -> ImageTagRegexp

### DIFF
--- a/autodeploy.go
+++ b/autodeploy.go
@@ -54,7 +54,7 @@ func (a AutoDeploy) checkAndDeploy(dp DeployProject, phase DeployPhase) {
 		log.Print(err)
 		return
 	}
-	tag, err := ecr.FindImageTagByRegexp(dp.ECRRegistryId(), dp.ECRRepository(), dp.FilterRegexp(), dp.TargetRegexp(), ImageTagVars{Branch: dp.DefaultBranch()})
+	tag, err := ecr.FindImageTagByRegexp(dp.ECRRegistryId(), dp.ECRRepository(), dp.ImageTagRegexp(), dp.TargetRegexp(), ImageTagVars{Branch: dp.DefaultBranch()})
 	if currentTag == tag || err != nil {
 		log.Printf("[INFO] Auto Deploy (%s:%s) is skipped", dp.ID, phase.Name)
 		return

--- a/model_combine.go
+++ b/model_combine.go
@@ -45,7 +45,7 @@ func (self ModelCombine) Deploy(pj DeployProject, phase string, option DeployOpt
 	if err != nil {
 		return o, err
 	}
-	option.Tag, err = ecr.FindImageTagByRegexp(pj.ECRRegistryId(), pj.ECRRepository(), pj.FilterRegexp(), pj.TargetRegexp(), ImageTagVars{Branch: option.Branch, Phase: phase})
+	option.Tag, err = ecr.FindImageTagByRegexp(pj.ECRRegistryId(), pj.ECRRepository(), pj.ImageTagRegexp(), pj.TargetRegexp(), ImageTagVars{Branch: option.Branch, Phase: phase})
 	if err != nil {
 		return o, err
 	}

--- a/model_job.go
+++ b/model_job.go
@@ -49,7 +49,7 @@ func (self ModelJob) Deploy(pj DeployProject, phase string, option DeployOption)
 		if err != nil {
 			return o, err
 		}
-		tag, err = ecr.FindImageTagByRegexp(pj.ECRRegistryId(), pj.ECRRepository(), pj.FilterRegexp(), pj.TargetRegexp(), ImageTagVars{Branch: option.Branch, Phase: phase})
+		tag, err = ecr.FindImageTagByRegexp(pj.ECRRegistryId(), pj.ECRRepository(), pj.ImageTagRegexp(), pj.TargetRegexp(), ImageTagVars{Branch: option.Branch, Phase: phase})
 		if err != nil {
 			return o, err
 		}

--- a/model_kustomize.go
+++ b/model_kustomize.go
@@ -36,7 +36,7 @@ func (self ModelKustomize) Prepare(pj DeployProject, phase string, branch string
 		if err != nil {
 			return o, err
 		}
-		tag, err = ecr.FindImageTagByRegexp(pj.ECRRegistryId(), pj.ECRRepository(), pj.FilterRegexp(), pj.TargetRegexp(), ImageTagVars{Branch: branch, Phase: phase})
+		tag, err = ecr.FindImageTagByRegexp(pj.ECRRegistryId(), pj.ECRRepository(), pj.ImageTagRegexp(), pj.TargetRegexp(), ImageTagVars{Branch: branch, Phase: phase})
 		if err != nil {
 			return o, err
 		}

--- a/model_lambda.go
+++ b/model_lambda.go
@@ -36,7 +36,7 @@ func (self ModelLambda) Deploy(pj DeployProject, phase string, option DeployOpti
 		if err != nil {
 			return o, err
 		}
-		tag, err = ecr.FindImageTagByRegexp(pj.ECRRegistryId(), pj.ECRRepository(), pj.FilterRegexp(), pj.TargetRegexp(), ImageTagVars{Branch: option.Branch, Phase: phase})
+		tag, err = ecr.FindImageTagByRegexp(pj.ECRRegistryId(), pj.ECRRepository(), pj.ImageTagRegexp(), pj.TargetRegexp(), ImageTagVars{Branch: option.Branch, Phase: phase})
 		if err != nil {
 			return o, err
 		}

--- a/project.go
+++ b/project.go
@@ -74,7 +74,15 @@ func (pj DeployProject) Steps() []string {
 	return pj.steps
 }
 
-func (pj DeployProject) FilterRegexp() string {
+// ImageTagRegexp returns the regexp to filter image tags.
+// This regexp is used to find the image tag from ECR.
+// The regexp is parsed as a template, and the following variables are available:
+//
+//	{{.Branch}}: The branch name of the target commit.
+//	{{.Phase}}: The phase name.
+//
+// See ECRClient.FindImageTagByRegexp for more details on how the regexp is used.
+func (pj DeployProject) ImageTagRegexp() string {
 	if pj.filterRegexp == "" {
 		return "^{{.Branch}}$"
 	}


### PR DESCRIPTION
so that it is clearer that it is used to filter image tags only.

Peviously, it was unclear about what are filtered by the regexp. It is image tags that are filtered, so make sure the name clearly represents that for readability.

Additionally, this makes the variable naming consistent between ImageTagRegexp and the existing ImageTagVars. ImageTagVars are used as the template parameters when parsing ImageTagRegexp as a Go template.

A consistent naming makes correlation between the two more apparent, which will also help readability.