### PR TITLE
Address govet findings

### DIFF
--- a/autodeploy.go
+++ b/autodeploy.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"github.com/nlopes/slack"
 	"log"
 	"time"
+
+	"github.com/nlopes/slack"
 )
 
 type AutoDeploy struct {
@@ -32,6 +33,8 @@ func (a AutoDeploy) Watch(sec int64) {
 }
 
 func (a AutoDeploy) CheckAndDeploy(sec int64, dp DeployProject, phase DeployPhase) {
+	// We don't stop the ticker as this is a long-running process
+	// with no way to cancel it.
 	t := time.NewTicker(time.Duration(sec) * time.Second)
 	for {
 		select {
@@ -39,7 +42,6 @@ func (a AutoDeploy) CheckAndDeploy(sec int64, dp DeployProject, phase DeployPhas
 			a.checkAndDeploy(dp, phase)
 		}
 	}
-	t.Stop()
 }
 
 func (a AutoDeploy) checkAndDeploy(dp DeployProject, phase DeployPhase) {

--- a/aws.go
+++ b/aws.go
@@ -78,7 +78,7 @@ func (e ECRClient) describeImages(registryId *string, repo *string, nextToken *s
 	}
 	outputs, err := e.client.DescribeImages(input)
 	if err != nil {
-		log.Print("Failed describe images, %v", err)
+		log.Printf("Failed to describe images: %v", err)
 		return []*ecr.ImageDetail{}
 	}
 	if outputs.NextToken != nil {

--- a/git.go
+++ b/git.go
@@ -173,7 +173,7 @@ func (g GitOperator) verify(w *git.Worktree) (err error) {
 
 	for path, status := range status {
 		if status.Staging != git.Modified {
-			fmt.Printf("[ERROR] There are some extra file updates. File: %c %s", status, path)
+			fmt.Printf("[ERROR] There are some extra file updates. File: %v %s", status, path)
 			return xerrors.New("There are some extra file updates")
 		}
 	}

--- a/interactor_jenkins.go
+++ b/interactor_jenkins.go
@@ -68,6 +68,9 @@ func (i InteractorJenkins) approve(target string, phase string, branch string, u
 	jobName := pj.JenkinsJob()
 	url := fmt.Sprintf("https://bot:%s@%s/job/%s/buildWithParameters?token=%s&cause=slack-bot&ENV=%s&BRANCH=%s", i.config.JenkinsBotToken, i.config.JenkinsHost, jobName, i.config.JenkinsJobToken, phase, branch)
 	resp, err := http.Get(url)
+	if err != nil {
+		return
+	}
 	defer resp.Body.Close()
 	res := fmt.Sprintf("Execute https://%s/job/%s/ \n selected branch: %s", i.config.JenkinsHost, jobName, branch)
 	if err != nil {

--- a/model_job.go
+++ b/model_job.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"encoding/json"
+
 	batchv1 "k8s.io/api/batch/v1"
 	yaml "k8s.io/apimachinery/pkg/util/yaml"
 )
@@ -92,6 +93,8 @@ func (self ModelJob) Deploy(pj DeployProject, phase string, option DeployOption)
 }
 
 func (self ModelJob) Watch(name, namespace string) error {
+	// We don't stop the ticker as this is a long-running process
+	// with no way to cancel it.
 	t := time.NewTicker(time.Duration(20) * time.Second)
 	log.Println("[INFO] Watch job", name)
 	for {
@@ -113,8 +116,6 @@ func (self ModelJob) Watch(name, namespace string) error {
 			}
 		}
 	}
-	t.Stop()
-	return nil
 }
 
 func init() {


### PR DESCRIPTION
that prevented go-test from running.

Note that the CI is still failing due to the hard requirement on an environment variable that isn't used by the tests currently.

```
2023/11/15 06:10:49 Set CONFIG_MANIFEST_REPOSITORY environment variable
FAIL	github.com/zaiminc/gocat	0.017s
```

Let's address that in another PR.

The govet findings I fixed in this change are:

```
$ go vet ./...
./interactor_jenkins.go:71:8: using resp before checking for errors
./aws.go:81:3: log.Print call has possible formatting directive %v
./git.go:176:4: fmt.Printf format %c has arg status of wrong type *github.com/go-git/go-git/v5.FileStatus
./autodeploy.go:42:2: unreachable code
./model_job.go:116:2: unreachable code
```