### PR TITLE
Revert "Add dependabot reviewers"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,3 @@ updates:
   reviewers:
   - yasukexxx
   - autumo
-  - kos31de

--- a/aws.go
+++ b/aws.go
@@ -72,7 +72,7 @@ func (e ECRClient) FindImageTagByRegexp(registryId string, repo string, rawFilte
 
 func (e ECRClient) describeImages(registryId *string, repo *string, nextToken *string) []*ecr.ImageDetail {
 	input := &ecr.DescribeImagesInput{
-		RegistryId:     registryId,
+		RegistryId: registryId,
 		RepositoryName: repo,
 		NextToken:      nextToken,
 	}


### PR DESCRIPTION
Reverts zaiminc/gocat#734

> POST https://api.github.com/repos/zaiminc/gocat/pulls/984/requested_reviewers: 422 - Reviews may only be requested from collaborators. One or more of the users or teams you specified is not a collaborator of the zaiminc/gocat repository. // See: https://docs.github.com/rest/pulls/review-requests#request-reviewers-for-a-pull-request
