### PR TITLE
Move the kustomize gitops plugin code to the appropriate file

### DIFF
--- a/gitops_plugin_kustomize.go
+++ b/gitops_plugin_kustomize.go
@@ -1,5 +1,10 @@
 package main
 
+import (
+	"fmt"
+	"strings"
+)
+
 // GitOpsPluginKustomize is a gocat gitops plugin to prepare
 // deployments using kustomize and gocat's builtin Git and GitHub support.
 // This is used when you want to use gocat as a workflow engine
@@ -12,4 +17,67 @@ type GitOpsPluginKustomize struct {
 
 func NewGitOpsPluginKustomize(github *GitHub, git *GitOperator) GitOpsPlugin {
 	return &GitOpsPluginKustomize{github: github, git: git}
+}
+
+func (k GitOpsPluginKustomize) Prepare(pj DeployProject, phase string, branch string, assigner User, tag string) (o GitOpsPrepareOutput, err error) {
+	o.status = DeployStatusFail
+	if tag == "" {
+		ecr, err := CreateECRInstance()
+		if err != nil {
+			return o, err
+		}
+		tag, err = ecr.FindImageTagByRegexp(pj.ECRRegistryId(), pj.ECRRepository(), pj.ImageTagRegexp(), pj.TargetRegexp(), ImageTagVars{Branch: branch, Phase: phase})
+		if err != nil {
+			return o, err
+		}
+	}
+
+	ph := pj.FindPhase(phase)
+	currentTag, err := ph.Destination.GetCurrentRevision(GetCurrentRevisionInput{github: k.github})
+	if err != nil {
+		return
+	}
+
+	if tag == currentTag {
+		o.status = DeployStatusAlready
+		return
+	}
+
+	commits, err := k.github.CommitsBetween(GitHubCommitsBetweenInput{
+		Repository:    pj.GitHubRepository(),
+		Branch:        branch,
+		FirstCommitID: currentTag,
+		LastCommitID:  tag,
+	})
+
+	commitlog := "*Commit Log*\n"
+	for _, c := range commits {
+		m := strings.Replace(c.Message, "\n", " ", -1)
+		commitlog = commitlog + "- " + m + "\n"
+	}
+
+	prBranch, err := k.git.PushDockerImageTag(pj.ID, ph, tag, pj.DockerRepository())
+	if err != nil {
+		return
+	}
+
+	prID, prNum, err := k.github.CreatePullRequest(prBranch, fmt.Sprintf("Deploy %s %s", pj.ID, branch), commitlog)
+	if err != nil {
+		return
+	}
+
+	if assigner.GitHubNodeID != "" {
+		err = k.github.UpdatePullRequest(prID, assigner.GitHubNodeID)
+		if err != nil {
+			return
+		}
+	}
+
+	o = GitOpsPrepareOutput{
+		PullRequestID:     prID,
+		PullRequestNumber: prNum,
+		Branch:            prBranch,
+		status:            DeployStatusSuccess,
+	}
+	return
 }

--- a/model_kustomize.go
+++ b/model_kustomize.go
@@ -1,10 +1,5 @@
 package main
 
-import (
-	"fmt"
-	"strings"
-)
-
 type ModelGitOps struct {
 	github *GitHub
 	git    *GitOperator
@@ -32,69 +27,6 @@ func (self GitOpsPrepareOutput) Status() DeployStatus {
 
 func (self GitOpsPrepareOutput) Message() string {
 	return "Success to deploy"
-}
-
-func (k GitOpsPluginKustomize) Prepare(pj DeployProject, phase string, branch string, assigner User, tag string) (o GitOpsPrepareOutput, err error) {
-	o.status = DeployStatusFail
-	if tag == "" {
-		ecr, err := CreateECRInstance()
-		if err != nil {
-			return o, err
-		}
-		tag, err = ecr.FindImageTagByRegexp(pj.ECRRegistryId(), pj.ECRRepository(), pj.ImageTagRegexp(), pj.TargetRegexp(), ImageTagVars{Branch: branch, Phase: phase})
-		if err != nil {
-			return o, err
-		}
-	}
-
-	ph := pj.FindPhase(phase)
-	currentTag, err := ph.Destination.GetCurrentRevision(GetCurrentRevisionInput{github: k.github})
-	if err != nil {
-		return
-	}
-
-	if tag == currentTag {
-		o.status = DeployStatusAlready
-		return
-	}
-
-	commits, err := k.github.CommitsBetween(GitHubCommitsBetweenInput{
-		Repository:    pj.GitHubRepository(),
-		Branch:        branch,
-		FirstCommitID: currentTag,
-		LastCommitID:  tag,
-	})
-
-	commitlog := "*Commit Log*\n"
-	for _, c := range commits {
-		m := strings.Replace(c.Message, "\n", " ", -1)
-		commitlog = commitlog + "- " + m + "\n"
-	}
-
-	prBranch, err := k.git.PushDockerImageTag(pj.ID, ph, tag, pj.DockerRepository())
-	if err != nil {
-		return
-	}
-
-	prID, prNum, err := k.github.CreatePullRequest(prBranch, fmt.Sprintf("Deploy %s %s", pj.ID, branch), commitlog)
-	if err != nil {
-		return
-	}
-
-	if assigner.GitHubNodeID != "" {
-		err = k.github.UpdatePullRequest(prID, assigner.GitHubNodeID)
-		if err != nil {
-			return
-		}
-	}
-
-	o = GitOpsPrepareOutput{
-		PullRequestID:     prID,
-		PullRequestNumber: prNum,
-		Branch:            prBranch,
-		status:            DeployStatusSuccess,
-	}
-	return
 }
 
 func (self ModelGitOps) Commit(pullRequestID string) error {


### PR DESCRIPTION
Follow-up for #973

Let me move some code to another file. No logic, functional, or naming changes.

---

As I and @pirlodog1125 discussed offline, I'd like to move the new `GitOpsPluginKustomize` type's existing `Prepare` function code to the appropriate file.

In #973 I just changed `Prepare`'s receiver from old `ModelKustomize` to new `GitOpsPluginKustomize`, without moving the function's code to the appropriate file, so that it is clear for reviewers that the change is only in the receiver type.

This completes the change, by finally moving code.
