### PR TITLE
Fix test missing envvar

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -72,7 +72,7 @@ func (e ECRClient) FindImageTagByRegexp(registryId string, repo string, rawFilte
 
 func (e ECRClient) describeImages(registryId *string, repo *string, nextToken *string) []*ecr.ImageDetail {
 	input := &ecr.DescribeImagesInput{
-		RegistryId: registryId,
+		RegistryId:     registryId,
 		RepositoryName: repo,
 		NextToken:      nextToken,
 	}

--- a/bot.go
+++ b/bot.go
@@ -9,40 +9,38 @@ import (
 	"github.com/nlopes/slack"
 )
 
-func init() {
-	err := InitConfig()
+func main() {
+	config, err := InitConfig()
 	if err != nil {
 		log.Fatal(err)
 	}
-}
 
-func main() {
 	client := slack.New(
-		Config.SlackOAuthToken,
+		config.SlackOAuthToken,
 		slack.OptionLog(log.New(os.Stdout, "slack-bot: ", log.Lshortfile|log.LstdFlags)),
 	)
-	github := CreateGitHubInstance(Config.GitHubAccessToken, Config.ManifestRepositoryOrg, Config.ManifestRepositoryName)
-	git := CreateGitOperatorInstance(Config.GitHubUserName, Config.GitHubAccessToken, Config.ManifestRepository)
+	github := CreateGitHubInstance(config.GitHubAccessToken, config.ManifestRepositoryOrg, config.ManifestRepositoryName, config.GitHubDefaultBranch)
+	git := CreateGitOperatorInstance(config.GitHubUserName, config.GitHubAccessToken, config.ManifestRepository, config.GitHubDefaultBranch)
 	userList := UserList{github: github, slackClient: client}
 	projectList := NewProjectList()
-	interactorContext := InteractorContext{projectList: &projectList, userList: &userList, github: github, git: git, client: client, config: Config}
+	interactorContext := InteractorContext{projectList: &projectList, userList: &userList, github: github, git: git, client: client, config: *config}
 	interactorFactory := NewInteractorFactory(interactorContext)
 	autoDeploy := NewAutoDeploy(client, &github, &git, &projectList)
 
 	log.SetOutput(os.Stdout)
-	if Config.EnableAutoDeploy {
+	if config.EnableAutoDeploy {
 		autoDeploy.Watch(60)
 	}
 
 	http.Handle("/events", SlackListener{
 		client:            client,
-		verificationToken: Config.SlackVerificationToken,
+		verificationToken: config.SlackVerificationToken,
 		projectList:       &projectList,
 		userList:          &userList,
 		interactorFactory: &interactorFactory,
 	})
 	http.Handle("/interaction", interactionHandler{
-		verificationToken: Config.SlackVerificationToken,
+		verificationToken: config.SlackVerificationToken,
 		client:            client,
 		projectList:       &projectList,
 		userList:          &userList,

--- a/git.go
+++ b/git.go
@@ -23,19 +23,21 @@ import (
 // GitOperator is our wrapper aroud go-git to do GitOps, and
 // tagging commits to correlate them with the container image tags.
 type GitOperator struct {
-	auth       transport.AuthMethod
-	repo       string
-	repository *git.Repository
-	username   string
+	auth          transport.AuthMethod
+	repo          string
+	repository    *git.Repository
+	username      string
+	defaultBranch string
 }
 
-func CreateGitOperatorInstance(username, token, repo string) (g GitOperator) {
+func CreateGitOperatorInstance(username, token, repo, defaultBranch string) (g GitOperator) {
 	g.auth = &http.BasicAuth{
 		Username: username, // yes, this can be anything except an empty string
 		Password: token,
 	}
 	g.repo = repo
 	g.username = username
+	g.defaultBranch = defaultBranch
 	g.Clone()
 	return
 }
@@ -77,8 +79,8 @@ func (g GitOperator) PushDockerImageTag(id string, phase DeployPhase, tag string
 		return
 	}
 	refName := plumbing.Master
-	if Config.GitHubDefaultBranch != "" {
-		refName = plumbing.ReferenceName(Config.GitHubDefaultBranch)
+	if g.defaultBranch != "" {
+		refName = plumbing.ReferenceName(g.defaultBranch)
 	}
 
 	err = w.Checkout(&git.CheckoutOptions{

--- a/project_test.go
+++ b/project_test.go
@@ -16,7 +16,7 @@ func TestProjectFind(t *testing.T) {
 		},
 	}
 	want := DeployProject{
-		ID:   "test",
+		ID:   "testid",
 		Kind: "testkind",
 	}
 	got := pl.Find("testid")

--- a/slack.go
+++ b/slack.go
@@ -7,8 +7,8 @@ import (
 	"log"
 	"net/http"
 	"regexp"
-	"strings"
 	"strconv"
+	"strings"
 
 	"github.com/nlopes/slack"
 	"github.com/nlopes/slack/slackevents"


### PR DESCRIPTION
Our CI was constantly failing due to a dependency on a global Config variable that needs to be initialized with envvars even for tests that do not related with the config.

<img width="467" alt="image" src="https://github.com/zaiminc/gocat/assets/22009/e62604a9-0fb1-4eab-8b8e-7d00b0dbbbd5">

I'd like to fix that, by removing the global variable Config and the static initializer a.k.a `func init`.

Instead of letting Go runtime calls `init` to initialize the global variable `Config`, we now call `InitConfigs` to explicitly initializes a `Config` object. That way we can test some code that does NOT depend on `Config` without the error.