### PR TITLE
lint: Log on slack message posting error

### DIFF
--- a/autodeploy.go
+++ b/autodeploy.go
@@ -80,7 +80,11 @@ func (a AutoDeploy) checkAndDeploy(dp DeployProject, phase DeployPhase) {
 			{Title: "Tag", Value: tag, Short: true},
 		}
 		msg := slack.Attachment{Color: "#36a64f", Title: ":white_check_mark: Succeed to auto deploy", Fields: fields}
-		a.client.PostMessage(phase.NotifyChannel, slack.MsgOptionAttachments(msg))
+		_, _, err = a.client.PostMessage(phase.NotifyChannel, slack.MsgOptionAttachments(msg))
+		if err != nil {
+			log.Print(err)
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
Addresses the golangci-lint finding below:

```
autodeploy.go:83:23: Error return value of `a.client.PostMessage` is not checked (errcheck)
                a.client.PostMessage(phase.NotifyChannel, slack.MsgOptionAttachments(msg))
```

We have 20 or more golangci-lint findings and that is failing the `lint` Actions job on every PR and commit.
I'll follow-up with more fixes like this one in due course, if you like!