### PR TITLE
ioutil has been deprecated since Go 1.19

### DIFF
--- a/git.go
+++ b/git.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -194,7 +194,7 @@ func (g GitOperator) commit(w *git.Worktree, targetFilePath string, o OverWrite)
 		fmt.Println("[ERROR] Failed to Open file: ", xerrors.New(err.Error()))
 		return
 	}
-	b, err := ioutil.ReadAll(file)
+	b, err := io.ReadAll(file)
 	if err != nil {
 		fmt.Println("[ERROR] Failed to ReadAll file: ", xerrors.New(err.Error()))
 		return

--- a/github.go
+++ b/github.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -54,7 +54,7 @@ func (g GitHub) GetFile(path string) (b []byte, err error) {
 		return
 	}
 	defer resp.Body.Close()
-	b, err = ioutil.ReadAll(resp.Body)
+	b, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Addresses the golangci-lint findings below:

```
git.go:5:2: SA1019: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package [io] or package [os], and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
        "io/ioutil"
        ^
github.go:6:2: SA1019: "io/ioutil" has been deprecated since Go 1.19: As of Go 1.16, the same functionality is now provided by package [io] or package [os], and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
        "io/ioutil"
        ^
```