### PR TITLE
Remove unused functions

### DIFF
--- a/autodeploy.go
+++ b/autodeploy.go
@@ -87,12 +87,3 @@ func (a AutoDeploy) checkAndDeploy(dp DeployProject, phase DeployPhase) {
 		}
 	}
 }
-
-func (a AutoDeploy) slackMessage(text string) slack.MsgOption {
-	listText := slack.NewTextBlockObject("mrkdwn", text, false, false)
-	listSection := slack.NewSectionBlock(listText, nil, nil)
-
-	return slack.MsgOptionBlocks(
-		listSection,
-	)
-}

--- a/interactor_context.go
+++ b/interactor_context.go
@@ -41,11 +41,6 @@ func (i InteractorContext) branchList(pj DeployProject, phase string) ([]slack.B
 	return []slack.Block{section, CloseButton()}, nil
 }
 
-func (i InteractorContext) plainBlock(msg string) []slack.Block {
-	blockObject := slack.NewTextBlockObject("mrkdwn", msg, false, false)
-	return []slack.Block{slack.NewSectionBlock(blockObject, nil, nil)}
-}
-
 func (i InteractorContext) plainBlocks(texts ...string) (blocks []slack.Block) {
 	for _, text := range texts {
 		block := slack.NewTextBlockObject("mrkdwn", text, false, false)


### PR DESCRIPTION
Addresses the golangci-lint findings below:

```
autodeploy.go:91:21: func `AutoDeploy.slackMessage` is unused (unused)
func (a AutoDeploy) slackMessage(text string) slack.MsgOption {
                    ^
interactor_context.go:44:28: func `InteractorContext.plainBlock` is unused (unused)
func (i InteractorContext) plainBlock(msg string) []slack.Block {
                           ^
```