### PR TITLE
Move ModelGitOps code into its own model_gitops.go

### DIFF
--- a/model_gitops.go
+++ b/model_gitops.go
@@ -1,0 +1,41 @@
+package main
+
+type ModelGitOps struct {
+	github *GitHub
+	git    *GitOperator
+	plugin GitOpsPlugin
+}
+
+type GitOpsPrepareOutput struct {
+	PullRequestID     string
+	PullRequestNumber int
+	Branch            string
+	status            DeployStatus
+}
+
+func (self GitOpsPrepareOutput) Status() DeployStatus {
+	return self.status
+}
+
+func (self GitOpsPrepareOutput) Message() string {
+	return "Success to deploy"
+}
+
+func (self ModelGitOps) Commit(pullRequestID string) error {
+	return self.github.MergePullRequest(pullRequestID)
+
+}
+
+func (self ModelGitOps) Deploy(pj DeployProject, phase string, option DeployOption) (do DeployOutput, err error) {
+	o, err := self.plugin.Prepare(pj, phase, option.Branch, option.Assigner, option.Tag)
+	if err != nil {
+		return
+	}
+	if o.Status() == DeployStatusSuccess {
+		err = self.Commit(o.PullRequestID)
+		if err != nil {
+			return
+		}
+	}
+	return o, nil
+}

--- a/model_kustomize.go
+++ b/model_kustomize.go
@@ -1,49 +1,9 @@
 package main
 
-type ModelGitOps struct {
-	github *GitHub
-	git    *GitOperator
-	plugin GitOpsPlugin
-}
-
 func NewModelKustomize(github *GitHub, git *GitOperator) ModelGitOps {
 	return ModelGitOps{
 		github: github,
 		git:    git,
 		plugin: NewGitOpsPluginKustomize(github, git),
 	}
-}
-
-type GitOpsPrepareOutput struct {
-	PullRequestID     string
-	PullRequestNumber int
-	Branch            string
-	status            DeployStatus
-}
-
-func (self GitOpsPrepareOutput) Status() DeployStatus {
-	return self.status
-}
-
-func (self GitOpsPrepareOutput) Message() string {
-	return "Success to deploy"
-}
-
-func (self ModelGitOps) Commit(pullRequestID string) error {
-	return self.github.MergePullRequest(pullRequestID)
-
-}
-
-func (self ModelGitOps) Deploy(pj DeployProject, phase string, option DeployOption) (do DeployOutput, err error) {
-	o, err := self.plugin.Prepare(pj, phase, option.Branch, option.Assigner, option.Tag)
-	if err != nil {
-		return
-	}
-	if o.Status() == DeployStatusSuccess {
-		err = self.Commit(o.PullRequestID)
-		if err != nil {
-			return
-		}
-	}
-	return o, nil
 }


### PR DESCRIPTION
Follow-up for #973 and #989

Let me move some code to a new source file. No logic, functional, or naming changes.

The history:

- In #973 I changed Prepare's receiver from old ModelKustomize to new GitOpsPluginKustomize, without moving the function's code to the appropriate file for easy reviewing
- In #989, I moved GitOpsPluginKustomize-related code in model_kustomize.go into gitops_plugin_kustomize.go as... that's the appropriate place
- In this pull request, I move ModelGitOps-related code in model_kustomize.go into model_gitops.go as... that's the right place, no? 😄 