### PR TITLE
Add git-clone tests and optional osfs git storage

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -20,7 +20,13 @@ func main() {
 		slack.OptionLog(log.New(os.Stdout, "slack-bot: ", log.Lshortfile|log.LstdFlags)),
 	)
 	github := CreateGitHubInstance(config.GitHubAccessToken, config.ManifestRepositoryOrg, config.ManifestRepositoryName, config.GitHubDefaultBranch)
-	git := CreateGitOperatorInstance(config.GitHubUserName, config.GitHubAccessToken, config.ManifestRepository, config.GitHubDefaultBranch)
+	git := CreateGitOperatorInstance(
+		config.GitHubUserName,
+		config.GitHubAccessToken,
+		config.ManifestRepository,
+		config.GitHubDefaultBranch,
+		os.Getenv("GOCAT_GITROOT"),
+	)
 	userList := UserList{github: github, slackClient: client}
 	projectList := NewProjectList()
 	interactorContext := InteractorContext{projectList: &projectList, userList: &userList, github: github, git: git, client: client, config: *config}

--- a/git_test.go
+++ b/git_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+func TestGit_FSOS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	var o GitOperator
+	o.repo = "https://github.com/zaiminc/gocat"
+	o.defaultBranch = "master"
+	o.gitRoot = t.TempDir()
+
+	if err := o.Clone(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGit_Mem(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	var o GitOperator
+	o.repo = "https://github.com/zaiminc/gocat"
+	o.defaultBranch = "master"
+
+	if err := o.Clone(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
To integrate with kanvas, we want gocat to git-clone and checkout the repository into the OS FS, not the in-memory FS, so that commands like `kustomize` that is called by kanvas just work.

To do so without breaking anything, I'd like to introduce an "optional" OS FS mode for our GitOperator.

Instead of cloning the repo into the in-memory FS, it clones the repo under the directory specified by the `GOCAT_GITROOT` envvar.

If the envvar is omitted, it falls back to the in-memory FS, which gives us a complete backward-compatibility.

To ensure the existing in-mem and the new osfs modes work, I've added tests that actually git-clone this repo. It might be "a bit" slow(approx. 2 secs) but much better than not having tests at all. WDYT?