### PR TITLE
Log on git-clone error for easier debugging

### DIFF
--- a/git.go
+++ b/git.go
@@ -77,9 +77,6 @@ func (g *GitOperator) Clone() error {
 	})
 	g.repository = r
 
-	if err != nil {
-		fmt.Println("[ERROR] ", err)
-	}
 	return err
 }
 

--- a/git.go
+++ b/git.go
@@ -50,7 +50,9 @@ func CreateGitOperatorInstance(username, token, repo, defaultBranch, gitRoot str
 	g.username = username
 	g.defaultBranch = defaultBranch
 	g.gitRoot = gitRoot
-	g.Clone()
+	if err := g.Clone(); err != nil {
+		fmt.Println("[ERROR] Failed to Clone: ", xerrors.New(err.Error()))
+	}
 	return
 }
 
@@ -172,7 +174,10 @@ func (g GitOperator) createAndCheckoutNewBranch(branch string) (*git.Worktree, e
 	err = w.Pull(&git.PullOptions{RemoteName: "origin", Auth: g.auth})
 	if err != nil && err != git.NoErrAlreadyUpToDate {
 		fmt.Println("[ERROR] Failed to Pull origin/master: ", xerrors.New(err.Error()))
-		g.Clone()
+		fmt.Println("[INFO] Running Clone to see if it fixes the issue")
+		if err := g.Clone(); err != nil {
+			fmt.Println("[ERROR] Failed to Clone: ", xerrors.New(err.Error()))
+		}
 	}
 	err = nil
 


### PR DESCRIPTION
Addresses the golangci-lint findings below:

```
git.go:53:9: Error return value of `g.Clone` is not checked (errcheck)
        g.Clone()
               ^
git.go:175:10: Error return value of `g.Clone` is not checked (errcheck)
                g.Clone()
                       ^
```

To clarify- I didn't change the behavior. It still doesn't return early on git-clone error and instead log the error for further investigation.

That's because I wasn't sure if returning early was correct- currently, we have two occasions that we do `Clone`. There might always be cases where the second or the subsequent `Clone` fixes a transient git-clone issue. Returning early breaks that behavior.