### PR TITLE
Enable having pull request link to another repo

### DIFF
--- a/interactor_kustomize.go
+++ b/interactor_kustomize.go
@@ -39,7 +39,12 @@ func (i InteractorGitOps) Request(pj DeployProject, phase string, branch string,
 			return
 		}
 
-		txt := slack.NewTextBlockObject("mrkdwn", fmt.Sprintf("<@%s>\n*%s*\n*%s*\n*%s* ブランチをデプロイしますか?\nhttps://github.com/%s/%s/pull/%d", assigner, pj.GitHubRepository(), phase, branch, i.github.org, i.github.repo, o.PullRequestNumber), false, false)
+		prHTMLURL := o.PullRequestHTMLURL
+		if prHTMLURL == "" {
+			prHTMLURL = fmt.Sprintf("https://github.com/%s/%s/pull/%d", i.github.org, i.github.repo, o.PullRequestNumber)
+		}
+
+		txt := slack.NewTextBlockObject("mrkdwn", fmt.Sprintf("<@%s>\n*%s*\n*%s*\n*%s* ブランチをデプロイしますか?\n%s", assigner, pj.GitHubRepository(), phase, branch, prHTMLURL), false, false)
 		btnTxt := slack.NewTextBlockObject("plain_text", "Deploy", false, false)
 		btn := slack.NewButtonBlockElement("", fmt.Sprintf("%s|%s_%d", i.actionHeader("approve"), o.PullRequestID, o.PullRequestNumber), btnTxt)
 		blocks = append(blocks, slack.NewSectionBlock(txt, nil, slack.NewAccessory(btn)))

--- a/model_gitops.go
+++ b/model_gitops.go
@@ -7,10 +7,11 @@ type ModelGitOps struct {
 }
 
 type GitOpsPrepareOutput struct {
-	PullRequestID     string
-	PullRequestNumber int
-	Branch            string
-	status            DeployStatus
+	PullRequestID      string
+	PullRequestNumber  int
+	PullRequestHTMLURL string
+	Branch             string
+	status             DeployStatus
 }
 
 func (self GitOpsPrepareOutput) Status() DeployStatus {


### PR DESCRIPTION
This is to fix the pull request link URL included in the slack message for kanvas-enabled gocat projects.

gocat has been included an URL to the pull request made against **the config (or manifests) repo**.

For kanvas support, we checkout out **an application repo** and let the `kanvas` command create a pull request to whatever repo specified in the kanvas config file included in the app repo.

Depending on how you wrote the kanvas config for the target app, the pull request URL included in the slack message can be correct or not. To make it always correct, we let `kanvas` return the URL for the PR it created, and gocat include the URL as-is, without the previous gocat assumption (which is wrong after kanvas support) that pull requests are made against the single config repo (specified via gocat `CONFIG_MANIFEST_REPOSITORY` envvar).