### PR TITLE
Add tests for kanvas and kustomize interactor factories

### DIFF
--- a/interactor_kanvas_test.go
+++ b/interactor_kanvas_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewInteractorKanvas(t *testing.T) {
+	git := GitOperator{}
+	github := GitHub{}
+	i := InteractorContext{
+		git:    git,
+		github: github,
+	}
+	got := NewInteractorKanavs(i)
+
+	i.kind = "kanvas"
+	want := InteractorGitOps{}
+	want.kind = "kanvas"
+	want.git = git
+	want.github = github
+	want.model = &GitOpsPluginKanvas{github: &github, git: &git}
+
+	require.Equal(t, want, got)
+}

--- a/interactor_kustomize_test.go
+++ b/interactor_kustomize_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewInteractorKustomize(t *testing.T) {
+	git := GitOperator{}
+	github := GitHub{}
+	i := InteractorContext{
+		git:    git,
+		github: github,
+	}
+	got := NewInteractorKustomize(i)
+
+	want := InteractorGitOps{}
+	want.kind = "kustomize"
+	want.git = git
+	want.github = github
+	want.model = &GitOpsPluginKustomize{github: &github, git: &git}
+
+	require.Equal(t, want, got)
+}


### PR DESCRIPTION
I wasn't sure if the way we initialize interactor in https://github.com/zaiminc/gocat/blob/cb3c45983952284ef5322ce35bf19e7c451a69ef/interactor_kustomize.go#L17-L20 is working as intended(we refer to `o` itself when initializing `o`... how does it work?).

I've added tests to confirm that it's working.