### PR TITLE
Fix kanvas support phase and path handling, along with more comments

### DIFF
--- a/gitops_plugin_kanvas.go
+++ b/gitops_plugin_kanvas.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	"github.com/davinci-std/kanvas/client"
 	"github.com/davinci-std/kanvas/client/cli"
@@ -40,17 +41,37 @@ func (k GitOpsPluginKanvas) Prepare(pj DeployProject, phase string, branch strin
 	}
 
 	ph := pj.FindPhase(phase)
-	currentTag, err := ph.Destination.GetCurrentRevision(GetCurrentRevisionInput{github: k.github})
-	if err != nil {
-		return o, err
+	if ph.Name == "" {
+		return o, fmt.Errorf("phase %s not found for project %s", phase, pj.ID)
 	}
 
-	if tag == currentTag {
-		o.status = DeployStatusAlready
-		return o, nil
-	}
-
+	// The head of the pull request is bot/docker-image-tag-<project_id>-<phase_name>-<tag>.
+	// And it's used by kanvas to create a pull request against the master or the main branch of the repository
+	// specified in the kanvas.yaml, not the repository that contains kanvas.yaml.
+	//
+	// Let's say you have two repositories:
+	// - myapp
+	// - infra
+	//
+	// myapp contains kanvas.yaml and infra contains the actual deployment configuration files.
+	//
+	// In this case, the head of the pull request is bot/docker-image-tag-<project_id>-<phase_name>-<tag>
+	// in the infra repository, not the myapp repository.
 	head := fmt.Sprintf("bot/docker-image-tag-%s-%s-%s", pj.ID, ph.Name, tag)
+
+	// Treat the kanvas.yaml as the way to generate the desired state of the deployment,
+	// not the desired state itself.
+	// That's why we don't create pull requests against the master or the main branch of the repository
+	// that contains kanvas.yaml!
+	//
+	// We use kanvas.yaml in the master or the main branch to do the deployment.
+	//
+	// Unlike gocat kustomize model, we don't create pull requests against the master or the main branch of
+	// the repository that contains kanvas.yaml.
+	//
+	// Instead, we let kanvas to create pull requests against the master or the main branch of the repository
+	// as defined in the kanvas.yaml.
+
 	wt, err := k.git.createAndCheckoutNewBranch(head)
 	if err != nil {
 		return o, err
@@ -60,6 +81,8 @@ func (k GitOpsPluginKanvas) Prepare(pj DeployProject, phase string, branch strin
 
 	applyOpts := client.ApplyOptions{
 		SkippedComponents: map[string]map[string]string{
+			// Any kanvas.yaml that can be used by gocat needs to have
+			// "image" component that uses the kanavs's docker provider for building the container image.
 			"image": {
 				"tag": tag,
 			},
@@ -71,29 +94,95 @@ func (k GitOpsPluginKanvas) Prepare(pj DeployProject, phase string, branch strin
 		applyOpts.PullRequestAssigneeIDs = []string{assigner.GitHubNodeID}
 	}
 
-	r, err := c.Apply(context.Background(), wt.Filesystem.Join("kanvas.yaml"), "production", applyOpts)
+	// path is the relative path to the kanvas.yaml from the root of the repository.
+	//
+	// In case the project's Phases look like this:
+	//
+	// 	Phases: |
+	// 	- name: staging
+	// 	  path: path/to/kanvas.yaml
+	// 	- name: production
+	// 	  path: path/to
+	//
+	// The path to the config file is path/to/kanvas.yaml in both cases.
+	path := ph.Path
+	if path == "" {
+		path = "kanvas.yaml"
+	} else if filepath.Base(path) != "kanvas.yaml" {
+		path = filepath.Join(path, "kanvas.yaml")
+	}
+
+	// We treat gocat "phase" as kanvas "environment".
+	//
+	// This means that kanvas.yaml need to have all the environments
+	// corresponding to the gocat phases.
+	//
+	// Let's say you have two gocat phases: staging and production.
+	// kanvas.yaml need to have both staging and production environments like this:
+	// 	environments:
+	//    staging: ...
+	//    production: ...
+	//    sandbox: ...
+	//    local: ...
+	// 	components:
+	//   ...
+	//
+	// This Apply call corresponds to the following kanvas command:
+	//
+	// 	KANVAS_PULLREQUEST_ASSIGNEE_IDS=< assigner.GitHubNodeID > \
+	// 	KANVAS_PULLREQUEST_HEAD=< head > \
+	// 	 kanvas apply --env <phase> --config <path> --skipped-jobs-outputs '{"image":{"tag":"<tag>"}}'
+	//
+	r, err := c.Apply(context.Background(), wt.Filesystem.Join(path), phase, applyOpts)
 	if err != nil {
 		return o, err
 	}
 
 	var (
-		prID  string
-		prNum int
+		prCreated bool
+		prID      string
+		prNum     int
+		// prHTMLURL string
 	)
 
 	for _, o := range r.Outputs {
 		if o.PullRequest != nil {
+			prCreated = true
+
 			prID = fmt.Sprintf("%d", o.PullRequest.ID)
 			prNum = o.PullRequest.Number
+			// prHTMLURL is the URL to the pull request in the config repository,
+			// not the repository that contains kanvas.yaml.
+			//
+			// This is necessary because unlike the kustomize model that creates pull requests
+			// against the specified repository, kanvas uses the kanvas.yaml in the repository
+			// specified in the gocat configmap, to create pull requests against the repository
+			// specified in the kanvas.yaml.
+			// prHTMLURL = o.PullRequest.HTMLURL
+
 			break
 		}
+	}
+
+	if !prCreated {
+		// Instead of determining if the desired image tag is already deployed or not by
+		// getting the current tag using:
+		//
+		// 	ph.Destination.GetCurrentRevision(GetCurrentRevisionInput{github: k.github})
+		//
+		// we determine it by checking if the pull request is created or not.
+		//
+		// That's possible because, if the image.tag is already deployed, kanvas won't create a pull request.
+		o.status = DeployStatusAlready
+		return o, nil
 	}
 
 	o = GitOpsPrepareOutput{
 		PullRequestID:     prID,
 		PullRequestNumber: prNum,
-		Branch:            head,
-		status:            DeployStatusSuccess,
+		// PullRequestHTMLURL: prHTMLURL,
+		Branch: head,
+		status: DeployStatusSuccess,
 	}
 	return o, nil
 }


### PR DESCRIPTION
3 key points:

- We let `kanvas` decide if the deployment is necessary or not (whereas gocat kustomize support was reading kustomization.yaml and read the image tag embedded in it, comparing it with the tag taken from ECR)
- We use gocat `phase` as kanvas `environment`. Let's say your `kanvas.yaml` had environments of `local`, `sandbox`, `staging`, and `production`. You may have gocat phases of `staging` and `production` only if you want to enable gocat for those two environments only.
- You can specify the path to the kanvas.yaml in gocat "phase" setting in the project configmap. For kustomize, you specify the path to kustomization.yaml or the directory that contains kustomization.yaml. For kanvas, you specify the path to kanvas.yaml or the directory containing it.