### PR TITLE
Enable cloning multiple repos when used with the kanvas plugin

### DIFF
--- a/git.go
+++ b/git.go
@@ -56,15 +56,65 @@ func CreateGitOperatorInstance(username, token, repo, defaultBranch, gitRoot str
 	return
 }
 
+// getLocalRepoRoot returns the path from the gocat's current working directory
+// to the root of the local git repository.
+//
+// The caller needs to be aware that the returned path can be either an absolute path
+// or a relative path.
+//
+// The returned path is relative to the gocat's current working directory,
+// if gitRoot is not an absolute path.
+//
+// In case you run gocat like this:
+//
+//	GOCAT_GITROOT=path/to/gitroot gocat ...
+//
+// it results in getLocalRepoRoot() returning "path/to/gitroot/$host/$owner/$repo".
+//
+// In case you run gocat like this:
+//
+//	GOCAT_GITROOT=/path/to/gitroot gocat ...
+//
+// it returns "/path/to/gitroot/$host/$owner/$repo".
+//
+// If gitRoot is empty, which means we are using in-memory filesystem,
+// we will return an empty string.
+func (g *GitOperator) getLocalRepoRoot() string {
+	if g.gitRoot != "" {
+		// Without this modification, we will end up with a nested directory structure like this:
+		//
+		// - $GOCAT_GITROOT
+		//   - https:
+		//     - github.com
+		//       - zaiminc
+		//         - gocat.git
+		//
+		// which is not what we want.
+		//
+		// Instead, we want:
+		//
+		// - $GOCAT_GITROOT
+		//  - github.com
+		//    - zaiminc
+		//      - gocat
+		repo := strings.ReplaceAll(g.repo, "https://", "")
+		repo = strings.ReplaceAll(repo, "/", string(os.PathSeparator))
+		repo = strings.TrimSuffix(repo, ".git")
+		return filepath.Join(g.gitRoot, repo)
+	}
+	return ""
+}
+
 func (g *GitOperator) Clone() error {
 	var (
 		storage storage.Storer
 		fs      billy.Filesystem
 	)
 	if g.gitRoot != "" {
-		fs = osfs.New(g.gitRoot)
+		repoRoot := g.getLocalRepoRoot()
+		fs = osfs.New(repoRoot)
 		storage = filesystem.NewStorage(
-			osfs.New(filepath.Join(g.gitRoot, ".git")),
+			osfs.New(filepath.Join(repoRoot, ".git")),
 			cache.NewObjectLRUDefault(),
 		)
 	} else {
@@ -78,6 +128,24 @@ func (g *GitOperator) Clone() error {
 	g.repository = r
 
 	return err
+}
+
+func (g GitOperator) Clean() error {
+	if p := g.getLocalRepoRoot(); p != "" {
+		// Do our best not to delete unrelated and unintended files!
+		//
+		// If there's a .git directory, it is more likely a git repository created gocat,
+		// so we can safely delete it.
+		dotGit := filepath.Join(p, ".git")
+		if _, err := os.Stat(dotGit); err != nil {
+			return fmt.Errorf("unable to stat %s: %w", dotGit, err)
+		}
+		if err := os.RemoveAll(p); err != nil {
+			return fmt.Errorf("unable to remove %s: %w", p, err)
+		}
+	}
+
+	return nil
 }
 
 func (g GitOperator) Repo() string {


### PR DESCRIPTION
gocat has previously been supposed to clone only one repository, which is the gitops config repository that contains every kustomize configs you deploy.

For kanvas, you need to clone other repos that has `kanvas.yaml`, and use that to create PRs against the config repo (and otherwise let kanvas do direct deployments without going through the config repo and PRs).

The way gocat's GitOperator work and was used did not support cloning multiple repositories. This pull request adds that. Please see the comment for the new function `getLocalRepoRoot` for more details.