### PR TITLE
Add kanvas to container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,22 @@ COPY . .
 
 RUN go build -o ./gocat
 
+FROM debian:bullseye AS deps
+
+RUN apt update && apt install -y curl
+
+ENV KANVAS_VERSION=0.8.0
+
+RUN curl -LO https://github.com/davinci-std/kanvas/releases/download/v${KANVAS_VERSION}/kanvas_${KANVAS_VERSION}_linux_amd64.tar.gz \
+    && tar -xzf kanvas_${KANVAS_VERSION}_linux_amd64.tar.gz \
+    && mv kanvas /usr/local/bin/kanvas \
+    && rm kanvas_${KANVAS_VERSION}_linux_amd64.tar.gz
+
 FROM debian:bullseye
 
 WORKDIR /src
 COPY --from=build /src/gocat /src/gocat
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=deps /usr/local/bin/kanvas /usr/local/bin/kanvas
 
 CMD /src/gocat
-

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,6 +7,14 @@ RUN apt-get update && \
   unzip awscliv2.zip && \
   ./aws/install
 
+ENV KANVAS_VERSION=0.8.0
+
+RUN apt install -y curl \
+    && curl -LO https://github.com/davinci-std/kanvas/releases/download/v${KANVAS_VERSION}/kanvas_${KANVAS_VERSION}_linux_amd64.tar.gz \
+    && tar -xzf kanvas_${KANVAS_VERSION}_linux_amd64.tar.gz \
+    && mv kanvas /usr/local/bin/kanvas \
+    && rm kanvas_${KANVAS_VERSION}_linux_amd64.tar.gz
+
 RUN mkdir /bot
 WORKDIR /bot
 


### PR DESCRIPTION
This adds the `kanvas` binary to container images so that gocat can actually deploy apps using `kanvas`.

The version of `kanvas` binary is supposed to be the same one as the client library version declared in go.mod:

https://github.com/zaiminc/gocat/blob/76150fb5700263a749e23841f1d25eb8e518badb/go.mod#L7