### PR TITLE
Bump kanvas to v0.9.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM debian:bullseye AS deps
 
 RUN apt update && apt install -y curl
 
-ENV KANVAS_VERSION=0.9.3
+ENV KANVAS_VERSION=0.9.4
 
 RUN curl -LO https://github.com/davinci-std/kanvas/releases/download/v${KANVAS_VERSION}/kanvas_${KANVAS_VERSION}_linux_amd64.tar.gz \
     && tar -xzf kanvas_${KANVAS_VERSION}_linux_amd64.tar.gz \

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.49.2
-	github.com/davinci-std/kanvas v0.9.3
+	github.com/davinci-std/kanvas v0.9.4
 	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/go-git/go-git/v5 v5.11.0
 	github.com/nlopes/slack v0.6.1-0.20191106133607-d06c2a2b3249

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davinci-std/kanvas v0.9.3 h1:LdtwmbZfN2mXFTgaoTtCovD27zR8/K9AEzS1C/S6uEM=
-github.com/davinci-std/kanvas v0.9.3/go.mod h1:J0GDS+y2SSHcCpw8F1JVTEECKMQe3oKwP4KT3qcwkNU=
+github.com/davinci-std/kanvas v0.9.4 h1:rDWkiQW2ckSqpMphP8DfF8dpuzdz/RlMTLCi2ZJmh7w=
+github.com/davinci-std/kanvas v0.9.4/go.mod h1:iegW3lgTIHAcbt8wi5THR3qBUft/3sWDINqyVlgiSDo=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a h1:mATvB/9r/3gvcejNsXKSkQ6lcIaNec2nyfOdlTBR2lU=
 github.com/emicklei/go-restful/v3 v3.9.0 h1:XwGDlfxEnQZzuopoqxwSEllNcCOM9DhhFyhFIIGKwxE=


### PR DESCRIPTION
This fixes the inability to clone private repositories using https:// git repository URLs.

Related: #1050