### PR TITLE
Add kustomize to container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,14 @@ RUN curl -LO https://github.com/davinci-std/kanvas/releases/download/v${KANVAS_V
     && mv kanvas /usr/local/bin/kanvas \
     && rm kanvas_${KANVAS_VERSION}_linux_amd64.tar.gz
 
+ENV KUSTOMIZE_VERSION=5.3.0
+
+RUN curl -LO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz \
+  && tar xzf ./kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz \
+  && mv kustomize /usr/local/bin/kustomize \
+  && rm kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz \
+  && chmod +x /usr/local/bin/kustomize
+
 FROM debian:bullseye
 
 RUN apt update && apt install -y git
@@ -29,6 +37,7 @@ RUN apt update && apt install -y git
 WORKDIR /src
 COPY --from=build /src/gocat /src/gocat
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=deps /usr/local/bin/kustomize /usr/local/bin/kustomize
 COPY --from=deps /usr/local/bin/kanvas /usr/local/bin/kanvas
 
 CMD /src/gocat


### PR DESCRIPTION
This is required by the gocat kanvas support as kanvas depends on the kustomize binary to edit the kustomization.yaml for gitops.