### PR TITLE
Bump kanvas to v0.10.0 and some fix

### DIFF
--- a/gitops_plugin_kanvas.go
+++ b/gitops_plugin_kanvas.go
@@ -120,6 +120,7 @@ func (k GitOpsPluginKanvas) Prepare(pj DeployProject, phase string, branch strin
 			// You can add any component named "prereq" in kanvas.yaml, and it is not used when triggered via gocat.
 			"prereq": {},
 		},
+		GitUserName:     git.username,
 		PullRequestHead: head,
 		EnvVars: map[string]string{
 			// This is a hack to make kanvas to use a directory that we can clean up later.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.49.2
-	github.com/davinci-std/kanvas v0.9.4
+	github.com/davinci-std/kanvas v0.10.0
 	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/go-git/go-git/v5 v5.11.0
 	github.com/nlopes/slack v0.6.1-0.20191106133607-d06c2a2b3249

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davinci-std/kanvas v0.9.4 h1:rDWkiQW2ckSqpMphP8DfF8dpuzdz/RlMTLCi2ZJmh7w=
-github.com/davinci-std/kanvas v0.9.4/go.mod h1:iegW3lgTIHAcbt8wi5THR3qBUft/3sWDINqyVlgiSDo=
+github.com/davinci-std/kanvas v0.10.0 h1:Boqe9nb4+/WohGBpIIfBFfaC5k0wtWrYgqo9ickK5UU=
+github.com/davinci-std/kanvas v0.10.0/go.mod h1:sYoKyLib2VxmfBjDTiRlBYpR+QDdYXbjrzn91a9eZOE=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a h1:mATvB/9r/3gvcejNsXKSkQ6lcIaNec2nyfOdlTBR2lU=
 github.com/emicklei/go-restful/v3 v3.9.0 h1:XwGDlfxEnQZzuopoqxwSEllNcCOM9DhhFyhFIIGKwxE=


### PR DESCRIPTION
This addresses the following issues:

- git-commit via kanvas gitops plugin fails when `git config user.name` is not run yet
- kanvas via gitops plugin fails to submit a pull request when the repo is cloned using https and token