### PR TITLE
Fix various lint errors

### DIFF
--- a/autodeploy.go
+++ b/autodeploy.go
@@ -36,11 +36,8 @@ func (a AutoDeploy) CheckAndDeploy(sec int64, dp DeployProject, phase DeployPhas
 	// We don't stop the ticker as this is a long-running process
 	// with no way to cancel it.
 	t := time.NewTicker(time.Duration(sec) * time.Second)
-	for {
-		select {
-		case <-t.C:
-			a.checkAndDeploy(dp, phase)
-		}
+	for range t.C {
+		a.checkAndDeploy(dp, phase)
 	}
 }
 

--- a/interactor_combine.go
+++ b/interactor_combine.go
@@ -20,8 +20,7 @@ func NewInteractorCombine(i InteractorContext) (o InteractorCombine) {
 }
 
 func (self InteractorCombine) Request(pj DeployProject, phase string, branch string, assigner string, channel string) ([]slack.Block, error) {
-	var txt *slack.TextBlockObject
-	txt = slack.NewTextBlockObject("mrkdwn", fmt.Sprintf("*%s*\n*%s*\n*%s* ブランチをデプロイしますか?", pj.ID, phase, branch), false, false)
+	txt := slack.NewTextBlockObject("mrkdwn", fmt.Sprintf("*%s*\n*%s*\n*%s* ブランチをデプロイしますか?", pj.ID, phase, branch), false, false)
 	btnTxt := slack.NewTextBlockObject("plain_text", "Deploy", false, false)
 	btn := slack.NewButtonBlockElement("", fmt.Sprintf("%s|%s_%s_%s", self.actionHeader("approve"), pj.ID, phase, branch), btnTxt)
 	section := slack.NewSectionBlock(txt, nil, slack.NewAccessory(btn))

--- a/interactor_lambda.go
+++ b/interactor_lambda.go
@@ -20,8 +20,7 @@ func NewInteractorLambda(i InteractorContext) (o InteractorLambda) {
 }
 
 func (self InteractorLambda) Request(pj DeployProject, phase string, branch string, assigner string, channel string) ([]slack.Block, error) {
-	var txt *slack.TextBlockObject
-	txt = slack.NewTextBlockObject("mrkdwn", fmt.Sprintf("*%s*\n*%s*\n*%s* ブランチをデプロイしますか?", pj.ID, phase, branch), false, false)
+	txt := slack.NewTextBlockObject("mrkdwn", fmt.Sprintf("*%s*\n*%s*\n*%s* ブランチをデプロイしますか?", pj.ID, phase, branch), false, false)
 	btnTxt := slack.NewTextBlockObject("plain_text", "Deploy", false, false)
 	btn := slack.NewButtonBlockElement("", fmt.Sprintf("%s|%s_%s_%s", self.actionHeader("approve"), pj.ID, phase, branch), btnTxt)
 	section := slack.NewSectionBlock(txt, nil, slack.NewAccessory(btn))


### PR DESCRIPTION
This addresses the following lint errors:

- S1021: should merge variable declaration with assignment on next line (gosimple)
- S1000: should use for range instead of `for { select {} }` (gosimple)
- S1002: should omit comparison to bool constant, can be simplified to `option.Wait` (gosimple)