### PR TITLE
Bump kanvas to 0.11.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM debian:bullseye AS deps
 
 RUN apt update && apt install -y curl
 
-ENV KANVAS_VERSION=0.11.0
+ENV KANVAS_VERSION=0.11.1
 
 RUN curl -LO https://github.com/davinci-std/kanvas/releases/download/v${KANVAS_VERSION}/kanvas_${KANVAS_VERSION}_linux_amd64.tar.gz \
     && tar -xzf kanvas_${KANVAS_VERSION}_linux_amd64.tar.gz \

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.49.2
-	github.com/davinci-std/kanvas v0.11.0
+	github.com/davinci-std/kanvas v0.11.1
 	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/go-git/go-git/v5 v5.11.0
 	github.com/nlopes/slack v0.6.1-0.20191106133607-d06c2a2b3249

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxG
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davinci-std/kanvas v0.11.0 h1:x7aCs73kAp/Mm8qZt/uMYmsAvRwUvST97lgTgY4Fbec=
-github.com/davinci-std/kanvas v0.11.0/go.mod h1:BPgZEi5mD89BQw7c7BvV6MFbEqqEb6wt3bkL2ShqteU=
+github.com/davinci-std/kanvas v0.11.1 h1:DXXdfW5lNDYSzR56CphjhSCD2JxPq44xyWn2/2anmDs=
+github.com/davinci-std/kanvas v0.11.1/go.mod h1:t1+LdLz7zQxIcrrwfG3UgNKMj235a6TqVI3Xiy7mqbM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a h1:mATvB/9r/3gvcejNsXKSkQ6lcIaNec2nyfOdlTBR2lU=
 github.com/emicklei/go-restful/v3 v3.9.0 h1:XwGDlfxEnQZzuopoqxwSEllNcCOM9DhhFyhFIIGKwxE=


### PR DESCRIPTION
This should fix the inability to actually omit git user.email setting.