### PR TITLE
Add lock and unlock gocat Slack commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
       - name: Set up Go
         uses: actions/setup-go@v4
         with:

--- a/bot.go
+++ b/bot.go
@@ -19,7 +19,7 @@ func main() {
 		config.SlackOAuthToken,
 		slack.OptionLog(log.New(os.Stdout, "slack-bot: ", log.Lshortfile|log.LstdFlags)),
 	)
-	github := CreateGitHubInstance(config.GitHubAccessToken, config.ManifestRepositoryOrg, config.ManifestRepositoryName, config.GitHubDefaultBranch)
+	github := CreateGitHubInstance("", config.GitHubAccessToken, config.ManifestRepositoryOrg, config.ManifestRepositoryName, config.GitHubDefaultBranch)
 	git := CreateGitOperatorInstance(
 		config.GitHubUserName,
 		config.GitHubAccessToken,

--- a/bot.go
+++ b/bot.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"sync"
 
 	"github.com/slack-go/slack"
 )
@@ -44,6 +45,7 @@ func main() {
 		projectList:       &projectList,
 		userList:          &userList,
 		interactorFactory: &interactorFactory,
+		mu:                &sync.Mutex{},
 	})
 	http.Handle("/interaction", interactionHandler{
 		verificationToken: config.SlackVerificationToken,

--- a/deploy/configmap.go
+++ b/deploy/configmap.go
@@ -72,7 +72,7 @@ func (c *Coordinator) getOrCreateConfigMap(ctx context.Context) (*corev1.ConfigM
 
 // getConfigMap creates a Kubernetes API client, and use it to retrieve the ConfigMap.
 func (c *Coordinator) getConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {
-	clientset, err := c.kubernetesClientSet()
+	clientset, err := c.ClientSet()
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func (c *Coordinator) getConfigMap(ctx context.Context) (*corev1.ConfigMap, erro
 }
 
 func (c *Coordinator) createConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {
-	clientset, err := c.kubernetesClientSet()
+	clientset, err := c.ClientSet()
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func (c *Coordinator) createConfigMap(ctx context.Context) (*corev1.ConfigMap, e
 }
 
 func (c *Coordinator) updateConfigMap(ctx context.Context, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
-	clientset, err := c.kubernetesClientSet()
+	clientset, err := c.ClientSet()
 	if err != nil {
 		return nil, err
 	}

--- a/deploy/kubernetes.go
+++ b/deploy/kubernetes.go
@@ -8,10 +8,38 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+// Kubernetes is a helper struct that provides a way to create and cache a Kubernetes API client.
+// The client is created using the KUBECONFIG file if exists, or the in-cluster configuration.
+// The client is cached to avoid creating multiple clients.
+//
+// Usage:
+//
+//	k := Kubernetes{}
+//	clientset, err := k.ClientSet()
+//	if err != nil {
+//	  return err
+//	}
+//	// Use the clientset
+//
+//	// Or you can embed Kubernetes in your struct:
+//	type MyStruct struct {
+//	  Kubernetes
+//	}
+//	func (m *MyStruct) MyMethod() error {
+//	  clientset, err := m.ClientSet()
+//	  if err != nil {
+//	    return err
+//	  }
+//	  // Use the clientset
+//	}
+type Kubernetes struct {
+	clientset clientset.Interface
+}
+
 // kubeconfigPath returns the path to the KUBECONFIG file,
 // which is either specified by the KUBECONFIG environment variable,
 // or the default path ~/.kube/config.
-func (c *Coordinator) kubeconfigPath() string {
+func (c *Kubernetes) kubeconfigPath() string {
 	kubeconfig := clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename()
 	if path := os.Getenv("KUBECONFIG"); path != "" {
 		kubeconfig = path
@@ -22,7 +50,7 @@ func (c *Coordinator) kubeconfigPath() string {
 
 // kubernetesClientSet creates a Kubernetes API client
 // that uses either the KUBECONFIG file if exists, or the in-cluster configuration.
-func (c *Coordinator) kubernetesClientSet() (clientset.Interface, error) {
+func (c *Kubernetes) ClientSet() (clientset.Interface, error) {
 	if c.clientset != nil {
 		return c.clientset, nil
 	}

--- a/deploy/lock.go
+++ b/deploy/lock.go
@@ -6,7 +6,6 @@ import (
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clientset "k8s.io/client-go/kubernetes"
 )
 
 // Coordinator provides a way to lock and unlock deployments made via gocat.
@@ -29,7 +28,7 @@ type Coordinator struct {
 	// ConfigMapName is the name of the ConfigMap.
 	ConfigMapName string
 
-	clientset clientset.Interface
+	Kubernetes
 }
 
 func NewCoordinator(ns, configMap string) *Coordinator {

--- a/deploy/lock_test.go
+++ b/deploy/lock_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,6 +19,11 @@ func TestLockUnlock(t *testing.T) {
 	}
 
 	c := NewCoordinator("default", "gocat-test")
+	defer func() {
+		if c, _ := c.ClientSet(); c != nil {
+			c.CoreV1().ConfigMaps("default").Delete(context.Background(), "gocat-test", metav1.DeleteOptions{})
+		}
+	}()
 
 	prevKubeconfig := os.Getenv("KUBECONFIG")
 	os.Setenv("KUBECONFIG", kubeconfigPath)

--- a/deploy/lock_test.go
+++ b/deploy/lock_test.go
@@ -21,7 +21,9 @@ func TestLockUnlock(t *testing.T) {
 	c := NewCoordinator("default", "gocat-test")
 	defer func() {
 		if c, _ := c.ClientSet(); c != nil {
-			c.CoreV1().ConfigMaps("default").Delete(context.Background(), "gocat-test", metav1.DeleteOptions{})
+			if err := c.CoreV1().ConfigMaps("default").Delete(context.Background(), "gocat-test", metav1.DeleteOptions{}); err != nil {
+				t.Log(err)
+			}
 		}
 	}()
 

--- a/github.go
+++ b/github.go
@@ -36,13 +36,18 @@ type GitHubInput struct {
 	Branch     string
 }
 
-func CreateGitHubInstance(token, org, repo, defaultBranch string) GitHub {
+func CreateGitHubInstance(url, token, org, repo, defaultBranch string) GitHub {
 	src := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token},
 	)
 	httpClient := oauth2.NewClient(context.Background(), src)
 
-	client := githubv4.NewClient(httpClient)
+	var client *githubv4.Client
+	if url != "" {
+		client = githubv4.NewEnterpriseClient(url, httpClient)
+	} else {
+		client = githubv4.NewClient(httpClient)
+	}
 	return GitHub{*client, httpClient, org, repo, defaultBranch}
 }
 

--- a/project.go
+++ b/project.go
@@ -34,6 +34,10 @@ type DeployPhase struct {
 	Destination   Destination `yaml:"destination"`
 }
 
+func (p DeployPhase) None() bool {
+	return p.Name == ""
+}
+
 type DeployProject struct {
 	// ID is the name of the configmap that defines the project.
 	ID                  string

--- a/slack.go
+++ b/slack.go
@@ -29,7 +29,7 @@ type SlackListener struct {
 	interactorFactory *InteractorFactory
 
 	coordinator *deploy.Coordinator
-	mu          sync.Mutex
+	mu          *sync.Mutex
 }
 
 func (s SlackListener) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/slack_test.go
+++ b/slack_test.go
@@ -143,7 +143,9 @@ func TestSlackLockUnlock(t *testing.T) {
 
 			// Returns ids and logins of the users who are members of the organization
 
-			w.Write([]byte(`{"data": {"organization": {"membersWithRole": {"nodes": [{"id": "U1234", "login": "user1"}]}}}}`))
+			if _, err := w.Write([]byte(`{"data": {"organization": {"membersWithRole": {"nodes": [{"id": "U1234", "login": "user1"}]}}}}`)); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
 		default:
 			http.Error(w, "not found", http.StatusNotFound)
 		}

--- a/slack_test.go
+++ b/slack_test.go
@@ -83,9 +83,6 @@ func TestSlackLockUnlock(t *testing.T) {
 	setupConfigMaps(t, clientset, myprojectConfigMap, githubuserMappingConfigMap, rolebindingConfigMap)
 	setupNamespace(t, clientset, "gocat")
 
-	var token = os.Getenv("SLACK_TOKEN")
-	require.NotEmpty(t, token, "SLACK_TOKEN must be set")
-
 	messages := make(chan message, 10)
 	nextMessage := func() message {
 		select {
@@ -146,7 +143,7 @@ func TestSlackLockUnlock(t *testing.T) {
 	}))
 	defer ghts.Close()
 
-	s := slack.New(token,
+	s := slack.New("no-need-to-use-a-token-because-we-are-using-a-fake-server",
 		slack.OptionAPIURL(ts.GetAPIURL()),
 	)
 

--- a/slack_test.go
+++ b/slack_test.go
@@ -181,6 +181,10 @@ func TestSlackLockUnlock(t *testing.T) {
 	)
 
 	userList := UserList{github: gh, slackClient: s}
+	// Set LOCAL so that NewProjectList uses the local kubeconfig
+	local := os.Getenv("LOCAL")
+	os.Setenv("LOCAL", "true")
+	defer os.Setenv("LOCAL", local)
 	projectList := NewProjectList()
 	interactorContext := InteractorContext{
 		projectList: &projectList,

--- a/slack_test.go
+++ b/slack_test.go
@@ -1,0 +1,289 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+	"github.com/slack-go/slack/slacktest"
+	"github.com/stretchr/testify/require"
+	"github.com/zaiminc/gocat/deploy"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+var myprojectConfigMap = corev1.ConfigMap{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "myproject1",
+		Labels: map[string]string{
+			"gocat.zaim.net/configmap-type": "project",
+		},
+	},
+	Data: map[string]string{
+		"Phases": `- name: production
+`,
+	},
+}
+
+const (
+	user1SlackDisplayName = "user1"
+	user1GitHubLogin      = "user1"
+)
+
+var githubuserMappingConfigMap = corev1.ConfigMap{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "githubuser-mapping",
+		Labels: map[string]string{
+			"gocat.zaim.net/configmap-type": "githubuser-mapping",
+		},
+	},
+	Data: map[string]string{
+		user1SlackDisplayName: user1GitHubLogin,
+	},
+}
+
+var rolebindingConfigMap = corev1.ConfigMap{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "rolebinding",
+		Labels: map[string]string{
+			"gocat.zaim.net/configmap-type": "rolebinding",
+		},
+	},
+	Data: map[string]string{
+		"Developer": fmt.Sprintf(`%s
+user3
+`, user1SlackDisplayName),
+	},
+}
+
+// TestSlackLockUnlock tests the lock and unlock commands against
+// a pre-configured Kubernetes cluster, fake Slack API, and fake GitHub API.
+// It verifies that the lock and unlock commands work as expected, by sending
+// messages to the fake Slack API and checking the messages that are sent from gocat.
+func TestSlackLockUnlock(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	var k = &deploy.Kubernetes{}
+	clientset, err := k.ClientSet()
+	require.NoError(t, err)
+
+	setupConfigMaps(t, clientset, myprojectConfigMap, githubuserMappingConfigMap, rolebindingConfigMap)
+	setupNamespace(t, clientset, "gocat")
+
+	var token = os.Getenv("SLACK_TOKEN")
+	require.NotEmpty(t, token, "SLACK_TOKEN must be set")
+
+	messages := make(chan message, 10)
+	nextMessage := func() message {
+		select {
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for message")
+		case m := <-messages:
+			return m
+		}
+		return message{}
+	}
+	ts := slacktest.NewTestServer(func(c slacktest.Customize) {
+		c.Handle("/conversations.history", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(``))
+		})
+		// List users
+		c.Handle("/users.list", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{"ok": true, "members": [{"id": "U1234", "name": "User 1", "profile": {"display_name": "user1"}}]}`))
+		})
+		// Message posted to the channel
+		c.Handle("/chat.postMessage", func(w http.ResponseWriter, r *http.Request) {
+			m := message{
+				channel: r.FormValue("channel"),
+				Blocks:  []block{},
+			}
+			blocksValue := r.FormValue("blocks")
+			if err := json.Unmarshal([]byte(blocksValue), &m.Blocks); err != nil {
+				t.Logf("failed to unmarshal blocks: %v", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			messages <- m
+			w.Write([]byte(`{"ok": true}`))
+		})
+	})
+	ts.Start()
+	defer ts.Stop()
+
+	// ghts is a test HTTP server that serves GitHub API v2 (GraphQL) responses.
+	ghts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/graphql":
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			t.Logf("request body: %s", string(body))
+
+			// Returns ids and logins of the users who are members of the organization
+
+			w.Write([]byte(`{"data": {"organization": {"membersWithRole": {"nodes": [{"id": "U1234", "login": "user1"}]}}}}`))
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer ghts.Close()
+
+	s := slack.New(token,
+		slack.OptionAPIURL(ts.GetAPIURL()),
+	)
+
+	config, err := InitConfig()
+	require.NoError(t, err)
+
+	gh := CreateGitHubInstance(
+		ghts.URL+"/graphql",
+		config.GitHubAccessToken,
+		config.ManifestRepositoryOrg,
+		config.ManifestRepositoryName,
+		config.GitHubDefaultBranch,
+	)
+	git := CreateGitOperatorInstance(
+		config.GitHubUserName,
+		config.GitHubAccessToken,
+		config.ManifestRepository,
+		config.GitHubDefaultBranch,
+		os.Getenv("GOCAT_GITROOT"),
+	)
+
+	userList := UserList{github: gh, slackClient: s}
+	projectList := NewProjectList()
+	interactorContext := InteractorContext{
+		projectList: &projectList,
+		userList:    &userList,
+		github:      gh,
+		git:         git,
+		client:      s,
+		config:      *config,
+	}
+	interactorFactory := NewInteractorFactory(interactorContext)
+
+	var l = &SlackListener{
+		client:            s,
+		verificationToken: "token",
+		projectList:       &projectList,
+		userList:          &userList,
+		interactorFactory: &interactorFactory,
+	}
+
+	require.NoError(t, l.handleMessageEvent(&slackevents.AppMentionEvent{
+		User:    "U1234",
+		Channel: "C1234",
+		Text:    "lock myproject1 production for deployment of revision a",
+	}))
+	require.Equal(t, "Locked myproject1 production", nextMessage().Text())
+
+	require.NoError(t, l.handleMessageEvent(&slackevents.AppMentionEvent{
+		User:    "U1234",
+		Channel: "C1234",
+		Text:    "lock myproject1 production for deployment of revision a",
+	}))
+	require.Equal(t, "deployment is locked", nextMessage().Text())
+
+	require.NoError(t, l.handleMessageEvent(&slackevents.AppMentionEvent{
+		User:    "U1234",
+		Channel: "C1234",
+		Text:    "unlock myproject1 production",
+	}))
+	require.Equal(t, "Unlocked myproject1 production", nextMessage().Text())
+
+	require.NoError(t, l.handleMessageEvent(&slackevents.AppMentionEvent{
+		User:    "U1234",
+		Channel: "C1234",
+		Text:    "unlock myproject1 production",
+	}))
+	require.Equal(t, "deployment is already unlocked", nextMessage().Text())
+
+	require.NoError(t, l.handleMessageEvent(&slackevents.AppMentionEvent{
+		User:    "U1235",
+		Channel: "C1234",
+		Text:    "lock myproject1 production for deployment of revision a",
+	}))
+	require.Equal(t, "you are not allowed to lock this project", nextMessage().Text())
+
+	require.NoError(t, l.handleMessageEvent(&slackevents.AppMentionEvent{
+		User:    "U1235",
+		Channel: "C1234",
+		Text:    "unlock myproject1 production",
+	}))
+	require.Equal(t, "find by slack user id \"U1235\": you are not allowed to lock this project", nextMessage().Text())
+}
+
+// Message is a message posted to the fake Slack API's chat.postMessage endpoint
+type message struct {
+	Blocks  []block
+	channel string
+}
+
+func (m message) Text() string {
+	for _, b := range m.Blocks {
+		if b.Type == "section" {
+			return b.Text.Text
+		}
+	}
+	return ""
+}
+
+type block struct {
+	// For example, "section"
+	Type string `json:"type"`
+	Text text   `json:"text"`
+}
+
+type text struct {
+	// For example, "mrkdwn"
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+func setupNamespace(t *testing.T, clientset kubernetes.Interface, name string) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	_, err := clientset.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+	if kerrors.IsAlreadyExists(err) {
+		_, err = clientset.CoreV1().Namespaces().Update(context.Background(), ns, metav1.UpdateOptions{})
+		require.NoError(t, err)
+	}
+	t.Cleanup(func() {
+		clientset.CoreV1().Namespaces().Delete(context.Background(), ns.Name, metav1.DeleteOptions{})
+	})
+}
+
+func setupConfigMaps(t *testing.T, clientset kubernetes.Interface, configMaps ...corev1.ConfigMap) {
+	for _, cm := range configMaps {
+		cm := cm
+		_, err := clientset.CoreV1().ConfigMaps("default").Create(context.Background(), &cm, metav1.CreateOptions{})
+		if kerrors.IsAlreadyExists(err) {
+			_, err = clientset.CoreV1().ConfigMaps("default").Update(context.Background(), &cm, metav1.UpdateOptions{})
+			require.NoError(t, err)
+		}
+		t.Cleanup(func() {
+			clientset.CoreV1().ConfigMaps("default").Delete(context.Background(), cm.Name, metav1.DeleteOptions{})
+		})
+	}
+}

--- a/slack_test.go
+++ b/slack_test.go
@@ -147,8 +147,16 @@ func TestSlackLockUnlock(t *testing.T) {
 		slack.OptionAPIURL(ts.GetAPIURL()),
 	)
 
-	config, err := InitConfig()
-	require.NoError(t, err)
+	// You usually do:
+	//   config, err := InitConfig()
+	// But for this test, we'll just set the config manually.
+	config := &CatConfig{
+		ManifestRepository:    "no-need-to-use-a-token-because-this-test-does-not-use-the-manifest-repository",
+		ManifestRepositoryOrg: "no-need-to-use-a-token-because-this-test-does-not-use-the-manifest-repository",
+		GitHubUserName:        "no-need-for-github-user-name-because-this-test-does-not-use-the-manifest-repository",
+		GitHubAccessToken:     "no-need-for-github-access-token-because-this-test-does-not-use-the-manifest-repository",
+		GitHubDefaultBranch:   "no-need-for-github-default-branch-because-this-test-does-not-use-the-manifest-repository",
+	}
 
 	gh := CreateGitHubInstance(
 		ghts.URL+"/graphql",


### PR DESCRIPTION
Adds the gocat Slack commands `@bot lock` and `@bot unlock` on top of #1123.

You can see a number of commits for refactoring, fixes, and CI improvements, but the gist of this PR are:

- 1780e59c25ee40600a31295ff1491a97ecb2c7c7 + dec0920886911a2a5217f67a92fb017180f4c5fb: Enhances the existing `SlackListener` who handles any `@bot command` to additionally support `@bot lock` and `@bot unlock`.
- 9bb907c39fa33724c103f8cea7ab210921a3c712: Adds the new test file `slack_test.go` for testing the gocat Slack bot's behavior, using a fake Slack API, a fake GitHub API, and a preconfigured Kubernetes cluster like `kind`.

# What's NOT included

There might be a plenty of potential improvements we can make further:

- Improve the lock error message to contain by who and why the lock is held: `project X environment ' has already been locked by user1 for REASON`
- Improve the lock error message to let the actor know who can resolve the issue, like `lock failed due to permission error: consult anyone with Developer role to lock it`.

But those are out of the scope of this PR!