### PR TITLE
Enable admins to forcefully unlock deployments

### DIFF
--- a/deploy/lock.go
+++ b/deploy/lock.go
@@ -38,7 +38,7 @@ func NewCoordinator(ns, configMap string) *Coordinator {
 	}
 }
 
-var ErrLocked = fmt.Errorf("deployment is locked")
+var ErrAlreadyLocked = fmt.Errorf("deployment is already locked")
 var ErrAlreadyUnlocked = fmt.Errorf("deployment is already unlocked")
 
 const (
@@ -82,7 +82,7 @@ func (c *Coordinator) lock(ctx context.Context, project, environment, user, reas
 	}
 
 	if value.Locked {
-		return ErrLocked
+		return ErrAlreadyLocked
 	}
 
 	if n := len(value.History); n >= MaxHistoryItems {

--- a/deploy/lock.go
+++ b/deploy/lock.go
@@ -190,7 +190,7 @@ type NotAllowedTounlockError struct {
 }
 
 func (e NotAllowedTounlockError) Error() string {
-	return fmt.Sprintf("user %s is not allowed to unlock", e.User)
+	return fmt.Sprintf("user %s is not allowed to unlock this project", e.User)
 }
 
 func newNotAllowedToUnlockError(user string) NotAllowedTounlockError {

--- a/deploy/lock_test.go
+++ b/deploy/lock_test.go
@@ -34,8 +34,8 @@ func TestLockUnlock(t *testing.T) {
 	ctx := context.Background()
 
 	require.NoError(t, c.Lock(ctx, "myproject1", "prod", "user1", "for deployment of revision a"))
-	require.ErrorIs(t, c.Lock(ctx, "myproject1", "prod", "user1", "for deployment of revision b"), ErrLocked)
-	require.ErrorIs(t, c.Lock(ctx, "myproject1", "prod", "user2", "for deployment of revision b"), ErrLocked)
+	require.ErrorIs(t, c.Lock(ctx, "myproject1", "prod", "user1", "for deployment of revision b"), ErrAlreadyLocked)
+	require.ErrorIs(t, c.Lock(ctx, "myproject1", "prod", "user2", "for deployment of revision b"), ErrAlreadyLocked)
 	require.ErrorIs(t, c.Unlock(ctx, "myproject1", "prod", "user2", false), newNotAllowedToUnlockError("user2"))
 	require.NoError(t, c.Unlock(ctx, "myproject1", "prod", "user2", true))
 	require.ErrorIs(t, c.Unlock(ctx, "myproject1", "prod", "user1", false), ErrAlreadyUnlocked)

--- a/user_test.go
+++ b/user_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCreateUserNamesInGroups(t *testing.T) {
+	var (
+		ul UserList
+
+		rolebindings = &v1.ConfigMapList{
+			Items: []v1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rolebinding1",
+						Labels: map[string]string{
+							"gocat.zaim.net/configmap-type": "rolebinding",
+						},
+					},
+					Data: map[string]string{
+						"Developer": "user1\nuser2\n",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rolebinding2",
+						Labels: map[string]string{
+							"gocat.zaim.net/configmap-type": "rolebinding",
+						},
+					},
+					Data: map[string]string{
+						"Admin": "user3\nuser4",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rolebinding3",
+						Labels: map[string]string{
+							"gocat.zaim.net/configmap-type": "rolebinding",
+						},
+					},
+					Data: map[string]string{
+						"Developer": "user5",
+						"Admin":     "user6",
+					},
+				},
+			},
+		}
+	)
+
+	userNamesInGroups := ul.createUserNamesInGroups(rolebindings)
+
+	if len(userNamesInGroups) != 2 {
+		t.Fatalf("userNamesInGroups length is not 2")
+	}
+
+	require.Equal(t,
+		map[string]struct{}{"user1": {}, "user2": {}, "user5": {}},
+		userNamesInGroups[RoleDeveloper],
+	)
+
+	require.Equal(t,
+		map[string]struct{}{"user3": {}, "user4": {}, "user6": {}},
+		userNamesInGroups[RoleAdmin],
+	)
+}


### PR DESCRIPTION
This improves #1124 to give admins the ability to unlock deployments forcefully.
Along the way, I enhanced `UserList` to provide additional information about whether the user has the role of `Admin` in addition to the existing `Developer` role.