### PR TITLE
Foundation for `@bot describe-locks`

### DIFF
--- a/deploy/lock_test.go
+++ b/deploy/lock_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -51,4 +52,88 @@ func TestLockUnlock(t *testing.T) {
 		require.NoError(t, c.Lock(ctx, "myproject1", "prod", user, fmt.Sprintf("for deployment of revision c+%d", u)))
 		require.NoError(t, c.Unlock(ctx, "myproject1", "prod", user, false))
 	}
+}
+
+type fakeClock struct {
+	now metav1.Time
+}
+
+func (f *fakeClock) Now() metav1.Time {
+	return f.now
+}
+
+func TestDescribeLocks(t *testing.T) {
+	// Ensure you run `KUBECONFIG=gocat-test-kubeconfig kind export kubeconfig` before running this test
+	kubeconfigPath := os.Getenv("GOCAT_TEST_KUBECONFIG")
+	if kubeconfigPath == "" {
+		t.Skip("GOCAT_TEST_KUBECONFIG is not set")
+	}
+
+	c := NewCoordinator("default", "gocat-test")
+	defer func() {
+		if c, _ := c.ClientSet(); c != nil {
+			if err := c.CoreV1().ConfigMaps("default").Delete(context.Background(), "gocat-test", metav1.DeleteOptions{}); err != nil {
+				t.Log(err)
+			}
+		}
+	}()
+
+	tim, err := time.Parse(time.RFC3339, "2021-09-01T00:00:00Z")
+	require.NoError(t, err)
+	tim = tim.In(time.Local)
+	now := metav1.Time{Time: tim}
+	c.Clock = &fakeClock{
+		now: now,
+	}
+
+	prevKubeconfig := os.Getenv("KUBECONFIG")
+	os.Setenv("KUBECONFIG", kubeconfigPath)
+	defer os.Setenv("KUBECONFIG", prevKubeconfig)
+
+	ctx := context.Background()
+
+	require.NoError(t, c.Lock(ctx, "myproject1", "prod", "user1", "for deployment of revision a"))
+
+	locks, err := c.DescribeLocks(ctx)
+	require.NoError(t, err)
+	require.Len(t, locks, 1)
+
+	require.Equal(t, map[string]Phase{
+		"prod": {
+			Locked: true,
+			LockHistory: []LockHistoryItem{
+				{
+					User:   "user1",
+					At:     now,
+					Reason: "for deployment of revision a",
+					Action: LockActionLock,
+				},
+			},
+		},
+	}, locks["myproject1"])
+
+	require.NoError(t, c.Unlock(ctx, "myproject1", "prod", "user1", false))
+
+	locks, err = c.DescribeLocks(ctx)
+	require.NoError(t, err)
+	require.Len(t, locks, 1)
+	require.Equal(t, map[string]Phase{
+		"prod": {
+			Locked: false,
+			LockHistory: []LockHistoryItem{
+				{
+					User:   "user1",
+					Action: LockActionLock,
+					Reason: "for deployment of revision a",
+					At:     now,
+				},
+				{
+					User:   "user1",
+					Action: LockActionUnlock,
+					Reason: "",
+					At:     now,
+				},
+			},
+		},
+	}, locks["myproject1"])
 }

--- a/slack.go
+++ b/slack.go
@@ -265,7 +265,7 @@ func (s *SlackListener) runCommand(cmd slackcmd.Command, triggeredBy string, rep
 	case *slackcmd.Lock:
 		msgOpt = s.lock(cmd, user, replyIn)
 	case *slackcmd.Unlock:
-		msgOpt = s.unlock(cmd, user, replyIn, false)
+		msgOpt = s.unlock(cmd, user, replyIn)
 	default:
 		panic("unreachable")
 	}
@@ -291,7 +291,7 @@ func (s *SlackListener) lock(cmd *slackcmd.Lock, triggeredBy User, replyIn strin
 }
 
 // unlock unlocks the given project and environment, and replies to the given channel.
-func (s *SlackListener) unlock(cmd *slackcmd.Unlock, triggeredBy User, replyIn string, force bool) slack.MsgOption {
+func (s *SlackListener) unlock(cmd *slackcmd.Unlock, triggeredBy User, replyIn string) slack.MsgOption {
 	if err := s.validateProjectEnvUser(cmd.Project, cmd.Env, triggeredBy, replyIn); err != nil {
 		return s.errorMessage(err.Error())
 	}


### PR DESCRIPTION
Adds some library code for the upcoming `@bot describe-locks` feature, which is used to review which projects/phases are locked and why.

- The `ConfigMapValue` struct has been renamed to a more specific `Phase` to represent what the configmap value contains.
- Added `deploy.Coordinator` a `DescribeLocks` function to obtain a map from project/phase to the `Phase` struct, so that the consumer of the library function pretty-print it as it likes.
- Added `TestDescribeLocks` for testing the new `DescribeLocks` function, along with the fake clock for the testing support.