### PR TITLE
`@bot describe locks` parsing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           go-version: '1.19'
           cache: true
       - name: Run tests
-        run: go test ./...
+        run: GOCAT_TEST_KUBECONFIG=$HOME/.kube/config go test ./...
   golangci:
     name: lint
     runs-on: ubuntu-latest

--- a/slackcmd/describe_locks.go
+++ b/slackcmd/describe_locks.go
@@ -1,0 +1,8 @@
+package slackcmd
+
+type DescribeLocks struct {
+}
+
+func (l *DescribeLocks) Name() string {
+	return "describe-locks"
+}

--- a/slackcmd/parse.go
+++ b/slackcmd/parse.go
@@ -1,17 +1,48 @@
 package slackcmd
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
 )
 
+type PatternError struct {
+	Pattern string
+}
+
+func (e PatternError) Error() string {
+	return fmt.Errorf("valid pattern is `%s`", e.Pattern).Error()
+}
+
+func patternError(pattern string) PatternError {
+	return PatternError{Pattern: pattern}
+}
+
 var lockUnlockPattern = regexp.MustCompile(`(unlock|lock) ([0-9a-zA-Z-]+) (staging|production|sandbox|stg|pro|prd)\s*(.*)`)
 
 func Parse(text string) (Command, error) {
+	cmd, err1 := parseLockUnlock(text)
+	if err1 == nil {
+		return cmd, nil
+	} else if !errors.As(err1, &PatternError{}) {
+		return nil, fmt.Errorf("invalid command %q: %w", text, err1)
+	}
+
+	cmd, err2 := parseDescribeLocks(text)
+	if err2 == nil {
+		return cmd, nil
+	} else if !errors.As(err2, &PatternError{}) {
+		return nil, fmt.Errorf("invalid command %q: %w", text, err2)
+	}
+
+	return nil, fmt.Errorf("invalid command %q: %v, %v", text, err1, err2)
+}
+
+func parseLockUnlock(text string) (Command, error) {
 	match := findLockUnlock(text)
 	if match == nil {
-		return nil, fmt.Errorf("invalid command %q: valid pattern is 'lock|unlock <project> <env> [for <reason>]", text)
+		return nil, patternError("lock|unlock <project> <env> [for <reason>]")
 	}
 
 	var (
@@ -24,7 +55,7 @@ func Parse(text string) (Command, error) {
 	switch command {
 	case "unlock":
 		if reason != "" {
-			return nil, fmt.Errorf("invalid command %q: unlock command does not accept reason", text)
+			return nil, errors.New("unlock command does not accept reason")
 		}
 
 		return &Unlock{
@@ -33,11 +64,11 @@ func Parse(text string) (Command, error) {
 		}, nil
 	case "lock":
 		if reason == "" {
-			return nil, fmt.Errorf("invalid command %q: lock command requires reason", text)
+			return nil, errors.New("lock command requires reason")
 		}
 
 		if !strings.HasPrefix(reason, "for ") {
-			return nil, fmt.Errorf("invalid command %q: reason must start with 'for'", text)
+			return nil, errors.New("reason must start with 'for'")
 		}
 
 		reason = strings.TrimPrefix(reason, "for ")
@@ -50,6 +81,14 @@ func Parse(text string) (Command, error) {
 	default:
 		panic("unreachable")
 	}
+}
+
+func parseDescribeLocks(text string) (Command, error) {
+	if text != "describe locks" {
+		return nil, patternError("describe locks")
+	}
+
+	return &DescribeLocks{}, nil
 }
 
 func findLockUnlock(text string) [][]string {


### PR DESCRIPTION
This enhances the `slackcmd` parser to be able to parse not only `lock` and `unlock` but also `describe locks`, which is going to be built on top of #1126.

Additionally, this PR contains a commit to set `GOCAT_TEST_KUBECONFIG` before running tests in CI. It's required to run tests for locking and unlocking deployments.

I'm going to submit another PR to implement the command based on this and #1126.